### PR TITLE
Loot Toasts, Ignore List, and Lockbox Tooltips

### DIFF
--- a/Data/Data.lua
+++ b/Data/Data.lua
@@ -21,9 +21,34 @@ ns.WAGO_URL = "https://addons.wago.io/addons/open-sesame"
 ]]
 ns.OPTIONS_REGISTRY = {
 	General = ADDON_NAME,
+	Notifications = ADDON_NAME .. "_Notifications",
+	Lockboxes = ADDON_NAME .. "_Lockboxes",
+	IgnoreList = ADDON_NAME .. "_IgnoreList",
 	Profiles = ADDON_NAME .. "_Profiles",
 	Diagnostics = ADDON_NAME .. "_Diagnostics",
 }
+
+--------------------------------------------------------------------------------
+-- Expansion
+--------------------------------------------------------------------------------
+
+--[[
+    Which expansion this client is. Item data is tagged with the expansion that
+    introduced it, so anything newer than the running client can be filtered out
+    before the add-on ever asks the client about it: those ids resolve to nothing
+    here, and a row built from one would sit as a bare number forever.
+]]
+ns.VANILLA = 1
+ns.TBC = 2
+ns.WRATH = 3
+
+if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+	ns.currentExpansion = ns.VANILLA
+elseif WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC then
+	ns.currentExpansion = ns.TBC
+else
+	ns.currentExpansion = ns.WRATH
+end
 
 --------------------------------------------------------------------------------
 -- Constants
@@ -37,10 +62,72 @@ ns.OPEN_RECHECK_DELAY = 0.25 -- Delay before re-checking a slot after opening
 ns.PICK_LOCK_RESCAN_DELAY = 0.5 -- Delay after Pick Lock before rescanning bags
 ns.STATUS_FLUSH_DELAY = 0.25 -- Delay after closing an interaction window before flushing a held status message
 ns.BAG_FULL_COOLDOWN = 10
+ns.ITEM_ANNOUNCE_COOLDOWN = 5 -- Seconds before the same item may be announced again
+ns.STATUS_REPEAT_COOLDOWN = 5 -- Seconds before an identical status message may print again
+
+--[[
+    The client's own red "pass" icon, reused as a blocked marker on the Ignore
+    List's tooltip line so the row reads as refused at a glance. Texture escapes
+    are the one kind of picture sanctioned in game text.
+]]
+ns.ICON_IGNORED = "|TInterface\\Buttons\\UI-GroupLoot-Pass-Up:14|t"
 ns.LOOT_SOUND_FILE = "Interface\\AddOns\\Open-Sesame\\Includes\\Sounds\\item-pick-up.ogg" -- Rare-loot chime; play with PlaySoundFile
 ns.BAG_FULL_SOUND_FALLBACK = 846 -- SoundKitID; play with PlaySound
 ns.LOOT_DELAY = 0.25
 ns.LOOT_SOUND_WINDOW = 1 -- Seconds after a corpse/chest loot during which CHAT_MSG_LOOT may play the rare-loot sound
+ns.LOOT_TOAST_FADE_DURATION = 0.5 -- Seconds the fade itself takes, once ns.LOOT_TOAST_DURATIONS' dwell has elapsed
+
+-- Seconds a toast stays up. Offered as a dropdown, so the steps widen as they grow.
+ns.LOOT_TOAST_DURATIONS = { 1, 2, 3, 5, 8, 13, 21 }
+
+--[[
+    Most rows on screen at once. Same widening steps as the durations above, so
+    the two dropdowns read as a pair. The list is joined by an Unlimited choice
+    stored as 0 - a sentinel, not a count, and the one value the cap code has to
+    special-case, since a literal cap of zero would retire every row on sight.
+]]
+ns.LOOT_TOAST_COUNTS = { 1, 2, 3, 5, 8, 13, 21 }
+ns.LOOT_TOAST_UNLIMITED = 0
+
+-- The face list itself comes from LibSharedMedia; only the bounds are ours.
+ns.LOOT_TOAST_FONT_SIZE_MIN = 8
+ns.LOOT_TOAST_FONT_SIZE_MAX = 24
+
+--[[
+    The client's own SetFont flag strings, in the order the dropdown offers them:
+    the weight ladder first, then the two monochrome variants. "NONE" is our
+    sentinel for the empty flag string, which SetFont wants instead of a name.
+]]
+ns.LOOT_TOAST_FONT_FLAGS = { "NONE", "OUTLINE", "THICKOUTLINE", "MONOCHROME", "MONOCHROMEOUTLINE" }
+
+--[[
+    One potion icon per item quality, colour-matched to the quality it stands
+    for, so a sample toast reads as that quality at a glance. Used only by the
+    unlock preview in Features/Loot-Toasts.lua; real toasts always draw the
+    looted item's own icon.
+]]
+
+-- { [quality] = iconPath }
+ns.LOOT_TOAST_SAMPLE_ICONS = {
+	[0] = "Interface\\Icons\\inv_potion_132", -- Poor (gray)
+	[1] = "Interface\\Icons\\inv_potion_133", -- Common (white)
+	[2] = "Interface\\Icons\\inv_potion_138", -- Uncommon (green)
+	[3] = "Interface\\Icons\\inv_potion_137", -- Rare (blue)
+	[4] = "Interface\\Icons\\inv_potion_134", -- Epic (purple)
+	[5] = "Interface\\Icons\\inv_potion_135", -- Legendary (orange)
+}
+
+--------------------------------------------------------------------------------
+-- Options Layout
+--------------------------------------------------------------------------------
+
+ns.OPTIONS_ROW_WIDTH = 2.6
+ns.OPTIONS_LABEL_WIDTH = 1.3
+ns.OPTIONS_CONTROL_WIDTH = ns.OPTIONS_ROW_WIDTH - ns.OPTIONS_LABEL_WIDTH
+ns.OPTIONS_REMOVE_ICON_WIDTH = 0.25 -- the item lists' remove column, sized to its icon
+ns.OPTIONS_SUB_INDENT_WIDTH = 0.115 -- the blank cell a sub-option row leads with
+ns.OPTIONS_SUB_LABEL_WIDTH = 1 -- a sub-row caption, sized to the caption not the grid
+ns.OPTIONS_SUB_CONTROL_WIDTH = 1.3 -- its control, with slack so the row never wraps
 
 --------------------------------------------------------------------------------
 -- Item Quality
@@ -62,9 +149,90 @@ ns.QUALITY_COLORS = {
 	["e6cc80"] = 5, -- Heirloom / Artifact
 }
 
+--[[
+    LOCKPICKING is the skill spell behind skill line 633, not something a player
+    casts. It is here because its NAME is the localized name of the Lockpicking
+    skill line, which is the only handle Features/Lockbox-Tooltips.lua has for
+    finding the player's rank in GetSkillLineInfo -- see the note there.
+]]
 ns.SPELLS = {
 	PICK_LOCK = 1804,
+	LOCKPICKING = 1809,
+	PICK_POCKET = 921,
 	SHADOWMELD = 20580,
+}
+
+--[[
+    PickupBag, the client's own bag-grab sound, for a Pick Pocket that actually
+    took something: https://www.wowhead.com/classic/sound=1183/pickupbag
+
+    Seconds a loot window may follow that cast and still be counted as its haul.
+    Pick Pocket's window opens immediately, so this only has to be long enough to
+    span the cast-to-loot gap, not to bridge anything the player did next.
+]]
+ns.PICK_POCKET_SOUND = 1183 -- SoundKitID; play with PlaySound
+ns.PICK_POCKET_LOOT_WINDOW = 1
+
+--[[
+    The item kinds Loot Toasts can show regardless of the quality threshold. All
+    but the last are read from GetItemInfoInstant, which answers from the client's
+    own database with no cold-cache nil, so the kind is recognised the first time
+    the item is looted. Class and subclass numbers are stable across every client
+    we target.
+
+    ITEM_BIND_ON_PICKUP is the odd one out: bindType comes from the full
+    GetItemInfo, which CAN answer nil on a cold cache. See the note in
+    Features/Loot-Toasts.lua for why that is acceptable there, and the
+    "GetItemInfo bindType" row in the Diagnostics API report, which proves the
+    return position on each client rather than trusting it.
+]]
+--[[
+    Class 1 is the client's "Container", which is a BAG - the thing loot goes in,
+    not the lockbox Open Sesame opens. The add-on's own openable containers are
+    ns.AllowedItems and are matched by id, never by class.
+
+    Quivers and ammo pouches are their OWN class rather than bags, which is a
+    distinction the client's item database makes and a hunter does not: both are
+    the bag you were hoping would drop. The Bags toggle covers the pair.
+]]
+ns.ITEM_CLASS_BAG = 1
+ns.ITEM_CLASS_QUIVER = 11
+ns.ITEM_CLASS_RECIPE = 9
+ns.ITEM_CLASS_QUEST = 12
+ns.ITEM_CLASS_KEY = 13
+ns.ITEM_CLASS_MISCELLANEOUS = 15
+ns.ITEM_SUBCLASS_COMPANION_PET = 2 -- of Miscellaneous
+ns.ITEM_SUBCLASS_MOUNT = 5 -- of Miscellaneous
+ns.ITEM_BIND_ON_PICKUP = 1 -- GetItemInfo's bindType, 14th return
+ns.ITEM_BIND_PROBE_ID = 6948 -- Hearthstone: Bind on Pickup, and in every bag
+
+--------------------------------------------------------------------------------
+-- Money
+--------------------------------------------------------------------------------
+
+--[[
+    Coin piles for the money toast, one per magnitude, so the icon says roughly how
+    much before the digits are read. Written as texture paths rather than the file
+    ids the same art is also known by, matching every other icon in the add-on.
+]]
+ns.MONEY_ICON_GOLD = "Interface\\Icons\\INV_Misc_Coin_02" -- 133785
+ns.MONEY_ICON_SILVER = "Interface\\Icons\\INV_Misc_Coin_04" -- 133787
+ns.MONEY_ICON_COPPER = "Interface\\Icons\\INV_Misc_Coin_06" -- 133789
+
+ns.COPPER_PER_SILVER = 100
+ns.COPPER_PER_GOLD = 10000
+
+--[[
+    One colour per coin, for the g/s/c suffixes while the numbers stay body white.
+    These are the CLIENT'S conventions rather than the add-on's, which is why they
+    sit apart from ns.PALETTE: gold, silver and copper look the way they look in
+    every money display in the game, and a player reads the unit off the colour
+    before they read the letter.
+]]
+ns.MONEY_PALETTE = {
+	GOLD = "FFD700",
+	SILVER = "C7C7CF",
+	COPPER = "EDA55F",
 }
 
 -- { [raceKey] = { [genderId] = soundId } }
@@ -82,6 +250,93 @@ ns.RACE_SOUNDS = {
 }
 
 --------------------------------------------------------------------------------
+-- Lockbox Skill Levels
+--------------------------------------------------------------------------------
+
+--[[
+    Required Lockpicking skill per locked container, for the tooltip line in
+    Features/Lockbox-Tooltips.lua. Covers the ns.AllowedItems entries whose value
+    is false, minus four with no number to give:
+
+      Thieven' Kit (7868)        Flagged Locked, publishes no skill number.
+      Floral Foundations (39014) Requires Inscription (50), not Lockpicking.
+      Dark Iron Lockbox (208838) Unknown.
+      Scarlet Junkbox (239248)   Unknown.
+
+    The two Unknowns are Season of Discovery rows that reach ns.AllowedItems
+    through the name-guess merge rule rather than from a source that carries a
+    skill number. A missing row means no tooltip line for that box, which is the
+    deliberate trade: none of the four gets a line rather than being given a
+    guessed one.
+
+    Values here are numbers and the tooltip formats them with %d, so a placeholder
+    string in this table would error on hover. An unknown box is absent from the
+    table, never present with a stand-in value.
+
+    The skill number is NOT in the world DB: item_template.lockid points into
+    Lock.dbc, which is client data, so these values were read off each item's own
+    warcraft.wiki.gg page. The four 225s in the classic tier are real, each
+    confirmed on its own page.
+
+    -- TODO: Add SQL Query
+
+    This lists the items that need a value, so the table can be checked for gaps
+    after regenerating ns.AllowedItems:
+
+    SELECT it.entry, it.name, it.lockid
+    FROM item_template it
+    WHERE it.lockid > 0
+      AND EXISTS (SELECT 1 FROM item_loot_template ilt WHERE ilt.entry = it.entry)
+    ORDER BY it.name;
+]]
+
+-- { [itemId] = requiredLockpickingSkill }
+
+ns.LOCKBOX_SKILL_LEVELS = {
+
+	--------------------------------------------------------------------------------
+	-- 01. World of Warcraft
+	--------------------------------------------------------------------------------
+
+	[16882] = 1, -- Battered Junkbox
+	[5760] = 225, -- Eternium Lockbox
+	[4633] = 25, -- Heavy Bronze Lockbox
+	[16885] = 250, -- Heavy Junkbox
+	[4634] = 70, -- Iron Lockbox
+	[13875] = 175, -- Ironbound Locked Chest
+	[5758] = 225, -- Mithril Lockbox
+	[4632] = 1, -- Ornate Bronze Lockbox
+	[13918] = 250, -- Reinforced Locked Chest
+	[4638] = 225, -- Reinforced Steel Lockbox
+	[6354] = 1, -- Small Locked Chest
+	[4637] = 175, -- Steel Lockbox
+	[4636] = 125, -- Strong Iron Lockbox
+	[16884] = 175, -- Sturdy Junkbox
+	[6355] = 70, -- Sturdy Locked Chest
+	[7209] = 1, -- Tazan's Satchel
+	[12033] = 275, -- Thaurissan Family Jewels
+	[5759] = 225, -- Thorium Lockbox
+	[16883] = 70, -- Worn Junkbox
+
+	--------------------------------------------------------------------------------
+	-- 02. World of Warcraft : The Burning Crusade
+	--------------------------------------------------------------------------------
+
+	[31952] = 325, -- Khorium Lockbox
+	[29569] = 300, -- Strong Junkbox
+
+	--------------------------------------------------------------------------------
+	-- 03. World of Warcraft : Wrath of the Lich King
+	--------------------------------------------------------------------------------
+
+	[43622] = 375, -- Froststeel Lockbox
+	[43575] = 350, -- Reinforced Junkbox
+	[42953] = 400, -- Strange Envelope
+	[45986] = 400, -- Tiny Titanium Lockbox
+	[43624] = 400, -- Titanium Lockbox
+}
+
+--------------------------------------------------------------------------------
 -- Colors
 --------------------------------------------------------------------------------
 
@@ -92,12 +347,13 @@ ns.RACE_SOUNDS = {
 ]]
 
 ns.PALETTE = {
-	TITLE = "FFD100", -- Gold: Titles, Headers, Section Names
+	TITLE = "FFD100", -- Gold: Titles, Headers, Section Names, Field Titles
 	INFO = "00BBFF", -- Blue: Interactions, Toggles, Links, Keybinds, Slash Commands
-	BODY = "CCCCCC", -- Silver: Descriptions, Help Text
+	BODY = "FFFFFF", -- White: Descriptions, Options Body Text
+	HELP = "CCCCCC", -- Silver: Pro Tips, Helper Text
 	TEXT = "FFFFFF", -- White: Messages, Values, Spell Names
-	ON = "33CC33", -- Green: Enabled / On
-	OFF = "CC3333", -- Red: Disabled / Off
+	ON = "33CC33", -- Green: On
+	OFF = "CC3333", -- Red: Off
 	SEPARATOR = "AAAAAA", -- Gray: Separators, Dividers
 	MUTED = "808080", -- Dark Gray: Meta-data, Version Numbers
 }
@@ -110,407 +366,4 @@ ns.ICONS = {
 	on = "Interface\\Icons\\inv_misc_bag_09_green",
 	paused = "Interface\\Icons\\inv_misc_bag_09_black",
 	off = "Interface\\Icons\\inv_misc_bag_09_red",
-}
-
---------------------------------------------------------------------------------
--- Item Database
---------------------------------------------------------------------------------
-
--- { [itemId] = canOpenImmediately (true) or requiresUnlock (false) }
--- Hand-curated by item ID; no source query.
-
-ns.AllowedItems = {
-
-	--------------------------------------------------------------------------------
-	-- 01. World of Warcraft
-	--------------------------------------------------------------------------------
-
-	[10456] = true, -- A Bulging Coin Purse
-	[15902] = true, -- A Crazy Grab Bag
-	[11883] = true, -- A Dingy Fanny Pack
-	[5335] = true, -- A Sack of Coins
-	[6755] = true, -- A Small Container of Gems
-	[11107] = true, -- A Small Pack
-	[21509] = true, -- Ahn'Qiraj War Effort Supplies
-	[21510] = true, -- Ahn'Qiraj War Effort Supplies
-	[21511] = true, -- Ahn'Qiraj War Effort Supplies
-	[21512] = true, -- Ahn'Qiraj War Effort Supplies
-	[21513] = true, -- Ahn'Qiraj War Effort Supplies
-	[22152] = true, -- Anthion's Pouch
-	[20231] = true, -- Arathor Advanced Care Package
-	[20233] = true, -- Arathor Basic Care Package
-	[20236] = true, -- Arathor Standard Care Package
-	[11955] = true, -- Bag of Empty Ooze Containers
-	[20603] = true, -- Bag of Spoils
-	[6356] = true, -- Battered Chest
-	[16882] = false, -- Battered Junkbox
-	[7973] = true, -- Big-mouth Clam
-	[6646] = true, -- Bloated Albacore
-	[6647] = true, -- Bloated Catfish
-	[21163] = true, -- Bloated Firefin
-	[6644] = true, -- Bloated Mackerel
-	[21243] = true, -- Bloated Mightfish
-	[6645] = true, -- Bloated Mud Snapper
-	[21162] = true, -- Bloated Oily Blackmouth
-	[13881] = true, -- Bloated Redgill
-	[21164] = true, -- Bloated Rockscale Cod
-	[13891] = true, -- Bloated Salmon
-	[6643] = true, -- Bloated Smallfish
-	[8366] = true, -- Bloated Trout
-	[10695] = true, -- Box of Empty Vials
-	[9541] = true, -- Box of Goodies
-	[9539] = true, -- Box of Rations
-	[9540] = true, -- Box of Spells
-	[6827] = true, -- Box of Supplies
-	[8502] = true, -- Bronze Lotterybox
-	[22746] = true, -- Buccaneer's Uniform
-	[16783] = true, -- Bundle of Reports
-	[21191] = true, -- Carefully Wrapped Present
-	[11887] = true, -- Cenarion Circle Cache
-	[20602] = true, -- Chest of Spoils
-	[21741] = true, -- Cluster Rocket Recipes
-	[21528] = true, -- Colossal Bag of Loot
-	[20808] = true, -- Combat Assignment
-	[5738] = true, -- Covert Ops Pack
-	[9265] = true, -- Cuergo's Hidden Treasure
-	[23022] = true, -- Curmudgeon's Payoff
-	[19422] = true, -- Darkmoon Faire Fortune
-	[20469] = true, -- Decoded True Believer Clippings
-	[20228] = true, -- Defiler's Advanced Care Package
-	[20229] = true, -- Defiler's Basic Care Package
-	[20230] = true, -- Defiler's Standard Care Package
-	[12849] = true, -- Demon Kissed Sack
-	[6351] = true, -- Dented Crate
-	[8647] = true, -- Egg Crate
-	[10752] = true, -- Emerald Encrusted Chest
-	[11617] = true, -- Eridan's Supplies
-	[5760] = false, -- Eternium Lockbox
-	[11024] = true, -- Evergreen Herb Casing
-	[11937] = true, -- Fat Sack of Coins
-	[10834] = true, -- Felhound Tracker Kit
-	[21363] = true, -- Festive Gift
-	[21131] = true, -- Followup Combat Assignment
-	[20805] = true, -- Followup Logistics Assignment
-	[21386] = true, -- Followup Logistics Assignment
-	[21133] = true, -- Followup Tactical Assignment
-	[8484] = true, -- Gadgetzan Water Co. Care Package
-	[21310] = true, -- Gaily Wrapped Present
-	[21270] = true, -- Gently Shaken Gift
-	[21271] = true, -- Gently Shaken Gift
-	[21979] = true, -- Gift of Adoration: Darnassus
-	[21980] = true, -- Gift of Adoration: Ironforge
-	[22164] = true, -- Gift of Adoration: Orgrimmar
-	[21981] = true, -- Gift of Adoration: Stormwind
-	[22165] = true, -- Gift of Adoration: Thunder Bluff
-	[22166] = true, -- Gift of Adoration: Undercity
-	[22167] = true, -- Gift of Friendship: Darnassus
-	[22168] = true, -- Gift of Friendship: Ironforge
-	[22169] = true, -- Gift of Friendship: Orgrimmar
-	[22170] = true, -- Gift of Friendship: Stormwind
-	[22171] = true, -- Gift of Friendship: Thunder Bluff
-	[22172] = true, -- Gift of Friendship: Undercity
-	[11423] = true, -- Gnome Engineer's Renewal Gift
-	[5857] = true, -- Gnome Prize Box
-	[11422] = true, -- Goblin Engineer's Renewal Gift
-	[5858] = true, -- Goblin Prize Box
-	[19296] = true, -- Greater Darkmoon Prize
-	[10773] = true, -- Hakkari Urn
-	[4633] = false, -- Heavy Bronze Lockbox
-	[8503] = true, -- Heavy Bronze Lotterybox
-	[13874] = true, -- Heavy Crate
-	[8505] = true, -- Heavy Iron Lotterybox
-	[16885] = false, -- Heavy Junkbox
-	[8507] = true, -- Heavy Mithril Lotterybox
-	[22648] = true, -- Hive'Ashi Dossier
-	[22649] = true, -- Hive'Regal Dossier
-	[22650] = true, -- Hive'Zora Dossier
-	[10569] = true, -- Hoard of the Black Dragonflight
-	[20367] = true, -- Hunting Gear
-	[9529] = true, -- Internal Warrior Equipment Kit L25
-	[9532] = true, -- Internal Warrior Equipment Kit L30
-	[21150] = true, -- Iron Bound Trunk
-	[4634] = false, -- Iron Lockbox
-	[8504] = true, -- Iron Lotterybox
-	[13875] = false, -- Ironbound Locked Chest
-	[10479] = true, -- Kovic's Trading Satchel
-	[10595] = true, -- Kum'isha's Junk
-	[12122] = true, -- Kum'isha's Junk
-	[19035] = true, -- Lard's Special Picnic Basket
-	[21743] = true, -- Large Cluster Rocket Recipes
-	[21742] = true, -- Large Rocket Recipes
-	[19297] = true, -- Lesser Darkmoon Prize
-	[21132] = true, -- Logistics Assignment
-	[21266] = true, -- Logistics Assignment
-	[18804] = true, -- Lord Grayson's Satchel
-	[21746] = true, -- Lucky Red Envelope
-	[21640] = true, -- Lunar Festival Fireworks Pack
-	[6307] = true, -- Message in a Bottle
-	[19298] = true, -- Minor Darkmoon Prize
-	[21228] = true, -- Mithril Bound Trunk
-	[5758] = false, -- Mithril Lockbox
-	[8506] = true, -- Mithril Lotterybox
-	[22320] = true, -- Mux's Quality Goods
-	[19425] = true, -- Mysterious Lockbox
-	[21042] = true, -- Narain's Special Kit
-	[15876] = true, -- Nathanos' Chest
-	[9537] = true, -- Neatly Wrapped Box
-	[20768] = true, -- Oozing Bag
-	[4632] = false, -- Ornate Bronze Lockbox
-	[19153] = true, -- Outrider Advanced Care Package
-	[19154] = true, -- Outrider Basic Care Package
-	[19155] = true, -- Outrider Standard Care Package
-	[11912] = true, -- Package of Empty Ooze Containers
-	[22155] = true, -- Pledge of Adoration: Darnassus
-	[22154] = true, -- Pledge of Adoration: Ironforge
-	[22156] = true, -- Pledge of Adoration: Orgrimmar
-	[21975] = true, -- Pledge of Adoration: Stormwind
-	[22158] = true, -- Pledge of Adoration: Thunder Bluff
-	[22157] = true, -- Pledge of Adoration: Undercity
-	[22159] = true, -- Pledge of Friendship: Darnassus
-	[22160] = true, -- Pledge of Friendship: Ironforge
-	[22161] = true, -- Pledge of Friendship: Orgrimmar
-	[22178] = true, -- Pledge of Friendship: Stormwind
-	[22162] = true, -- Pledge of Friendship: Thunder Bluff
-	[22163] = true, -- Pledge of Friendship: Undercity
-	[13247] = true, -- Quartermaster Zigris' Footlocker
-	[13918] = false, -- Reinforced Locked Chest
-	[4638] = false, -- Reinforced Steel Lockbox
-	[6715] = true, -- Ruined Jumper Cables
-	[18636] = true, -- Ruined Jumper Cables XL
-	[11938] = true, -- Sack of Gems
-	[20601] = true, -- Sack of Spoils
-	[21156] = true, -- Scarab Bag
-	[7190] = true, -- Scorched Rocket Boots
-	[20767] = true, -- Scum Covered Bag
-	[22568] = true, -- Sealed Craftsman's Writ
-	[6357] = true, -- Sealed Crate
-	[19152] = true, -- Sentinel Advanced Care Package
-	[19150] = true, -- Sentinel Basic Care Package
-	[19151] = true, -- Sentinel Standard Care Package
-	[20766] = true, -- Slimy Bag
-	[5523] = true, -- Small Barnacled Clam
-	[15699] = true, -- Small Brown-wrapped Package
-	[6353] = true, -- Small Chest
-	[6354] = false, -- Small Locked Chest
-	[21740] = true, -- Small Rocket Recipes
-	[11966] = true, -- Small Sack of Coins
-	[21216] = true, -- Smokywood Pastures Extra-Special Gift
-	[17727] = true, -- Smokywood Pastures Gift Pack
-	[17685] = true, -- Smokywood Pastures Sampler
-	[17726] = true, -- Smokywood Pastures Special Gift
-	[21315] = true, -- Smokywood Satchel
-	[15874] = true, -- Soft-shelled Clam
-	[9363] = true, -- Sparklematic-Wrapped Box
-	[4637] = false, -- Steel Lockbox
-	[11442] = true, -- Stormwind Deputy Kit
-	[4636] = false, -- Strong Iron Lockbox
-	[16884] = false, -- Sturdy Junkbox
-	[6355] = false, -- Sturdy Locked Chest
-	[23224] = true, -- Summer Gift Package
-	[20809] = true, -- Tactical Assignment
-	[7209] = false, -- Tazan's Satchel
-	[7870] = true, -- Thaumaturgy Vessel Lockbox
-	[12033] = false, -- Thaurissan Family Jewels
-	[5524] = true, -- Thick-shelled Clam
-	[7868] = false, -- Thieven' Kit
-	[5759] = false, -- Thorium Lockbox
-	[21327] = true, -- Ticking Present
-	[20708] = true, -- Tightly Sealed Trunk
-	[11568] = true, -- Torwa's Pouch
-	[20393] = true, -- Treat Bag
-	[12339] = true, -- Vaelan's Gift
-	[6352] = true, -- Waterlogged Crate
-	[21113] = true, -- Watertight Trunk
-	[16883] = false, -- Worn Junkbox
-	[22137] = true, -- Ysida's Satchel
-	[22233] = true, -- Zigris' Footlocker
-
-	--------------------------------------------------------------------------------
-	-- 02. World of Warcraft: The Burning Crusade
-	--------------------------------------------------------------------------------
-
-	[34583] = true, -- Aldor Supplies Package
-	[34587] = true, -- Aldor Supplies Package
-	[34592] = true, -- Aldor Supplies Package
-	[34595] = true, -- Aldor Supplies Package
-	[28499] = true, -- Arakkoa Hunter's Supplies
-	[31955] = true, -- Arelion's Knapsack
-	[34863] = true, -- Bag of Fishing Treasures
-	[35348] = true, -- Bag of Fishing Treasures
-	[25423] = true, -- Bag of Premium Gems
-	[33844] = true, -- Barrel of Fish
-	[35313] = true, -- Bloated Barbed Gill Trout
-	[35286] = true, -- Bloated Giant Sunfish
-	[28135] = true, -- Bomb Crate
-	[34503] = true, -- Box of Adamantite Shells
-	[191061] = true, -- Brilliant Glass
-	[35945] = true, -- Brilliant Glass
-	[25422] = true, -- Bulging Sack of Gems
-	[23921] = true, -- Bulging Sack of Silver
-	[30320] = true, -- Bundle of Nether Spikes
-	[34548] = true, -- Cache of the Shattered Sun
-	[33857] = true, -- Crate of Meat
-	[34077] = true, -- Crudely Wrapped Gift
-	[27513] = true, -- Curious Crate
-	[30650] = true, -- Dertrok's Wand Case
-	[187714] = true, -- Enlistment Bonus
-	[187799] = true, -- Enlistment Bonus
-	[24336] = true, -- Fireproof Satchel
-	[25424] = true, -- Gem-Stuffed Envelope
-	[262788] = true, -- Grand Gift
-	[37586] = true, -- Handful of Candy
-	[27481] = true, -- Heavy Supply Crate
-	[33928] = true, -- Hollowed Bone Decanter
-	[27511] = true, -- Inscribed Scrollcase
-	[24476] = true, -- Jaggal Clam
-	[31952] = false, -- Khorium Lockbox
-	[32777] = true, -- Kronk's Grab Bag
-	[32626] = true, -- Large Copper Metamorphosis Geode
-	[32629] = true, -- Large Gold Metamorphosis Geode
-	[32624] = true, -- Large Iron Metamorphosis Geode
-	[32628] = true, -- Large Silver Metamorphosis Geode
-	[32462] = true, -- Morthis' Materials
-	[27446] = true, -- Mr. Pinchy's Gift
-	[23895] = true, -- Netted Goods
-	[23846] = true, -- Nolkai's Box
-	[31408] = true, -- Offering of the Sha'tar
-	[32835] = true, -- Ogri'la Care Package
-	[31800] = true, -- Outcast's Cache
-	[24402] = true, -- Package of Identified Plants
-	[35512] = true, -- Pocket Full of Snow
-	[37605] = true, -- Pouch of Pennies
-	[31522] = true, -- Primal Mooncloth Supplies
-	[32064] = true, -- Protectorate Treasure Cache
-	[33045] = true, -- Renn's Supplies
-	[34584] = true, -- Scryer Supplies Package
-	[34585] = true, -- Scryer Supplies Package
-	[34593] = true, -- Scryer Supplies Package
-	[34594] = true, -- Scryer Supplies Package
-	[33926] = true, -- Sealed Scroll Case
-	[35232] = true, -- Shattered Sun Supplies
-	[32724] = true, -- Sludge-covered Object
-	[32627] = true, -- Small Copper Metamorphosis Geode
-	[32630] = true, -- Small Gold Metamorphosis Geode
-	[32625] = true, -- Small Iron Metamorphosis Geode
-	[32631] = true, -- Small Silver Metamorphosis Geode
-	[29569] = false, -- Strong Junkbox
-	[32561] = true, -- Tier 5 Arrow Box
-	[25419] = true, -- Unmarked Bag of Gems
-	[30260] = true, -- Voren'thal's Package
-	[34426] = true, -- Winter Veil Gift
-
-	--------------------------------------------------------------------------------
-	-- 03. World of Warcraft: Wrath of the Lich King
-	--------------------------------------------------------------------------------
-
-	[44663] = true, -- Abandoned Adventurer's Satchel
-	[44161] = true, -- Arcane Tarot
-	[39903] = true, -- Argent Crusade Gratuity
-	[39904] = true, -- Argent Crusade Gratuity
-	[46007] = true, -- Bag of Fishing Treasures
-	[52274] = true, -- Bag of Shaman Stuff
-	[52344] = true, -- Bag of Shaman Stuff
-	[34119] = true, -- Black Conrad's Treasure
-	[45328] = true, -- Bloated Slippery Eel
-	[40308] = true, -- Bonework Soul Jar
-	[46809] = true, -- Bountiful Cookbook
-	[46810] = true, -- Bountiful Cookbook
-	[202269] = true, -- Bounty Satchel
-	[208157] = true, -- Bounty Satchel
-	[44951] = true, -- Box of Bombs
-	[49909] = true, -- Box of Chocolates
-	[35745] = true, -- Box of Treasure
-	[49926] = true, -- Brazie's Black Book of Secrets
-	[45072] = true, -- Brightly Colored Egg
-	[44700] = true, -- Brooding Darkwater Clam
-	[52676] = true, -- Cache of the Ley-Guardian
-	[45724] = true, -- Champion's Purse
-	[39883] = true, -- Cracked Egg
-	[34871] = true, -- Crafty's Sack
-	[50161] = true, -- Dinner Suit Box
-	[39014] = false, -- Floral Foundations
-	[43622] = false, -- Froststeel Lockbox
-	[54537] = true, -- Heart-Shaped Box
-	[44751] = true, -- Hyldnir Spoils
-	[44943] = true, -- Icy Prism
-	[54535] = true, -- Keg-Shaped Treasure Chest
-	[50301] = true, -- Landro's Pet Box
-	[45878] = true, -- Large Sack of Ulduar Spoils
-	[54516] = true, -- Loot-Filled Pumpkin
-	[50160] = true, -- Lovely Dress Box
-	[35792] = true, -- Mage Hunter Personal Effects
-	[41426] = true, -- Magically Wrapped Gift
-	[37168] = true, -- Mysterious Tarot
-	[199210] = true, -- Northrend Adventuring Supplies
-	[200238] = true, -- Northrend Adventuring Supplies
-	[200239] = true, -- Northrend Adventuring Supplies
-	[200240] = true, -- Northrend Adventuring Supplies
-	[46812] = true, -- Northrend Mystery Gem Pouch
-	[39418] = true, -- Ornately Jeweled Box
-	[43556] = true, -- Patroller's Pack
-	[44475] = true, -- Reinforced Crate
-	[43575] = false, -- Reinforced Junkbox
-	[44718] = true, -- Ripe Disgusting Jar
-	[52006] = true, -- Sack of Frosty Treasures
-	[38539] = true, -- Sack of Gold
-	[45875] = true, -- Sack of Ulduar Spoils
-	[54536] = true, -- Satchel of Chilled Goods
-	[51999] = true, -- Satchel of Helpful Goods
-	[52000] = true, -- Satchel of Helpful Goods
-	[52001] = true, -- Satchel of Helpful Goods
-	[52002] = true, -- Satchel of Helpful Goods
-	[52003] = true, -- Satchel of Helpful Goods
-	[52004] = true, -- Satchel of Helpful Goods
-	[52005] = true, -- Satchel of Helpful Goods
-	[44163] = true, -- Shadowy Tarot
-	[44113] = true, -- Small Spice Bag
-	[41888] = true, -- Small Velvet Bag
-	[49631] = true, -- Standard Apothecary Serving Kit
-	[42953] = false, -- Strange Envelope
-	[44142] = true, -- Strange Tarot
-	[54467] = true, -- Tabard Lost & Found
-	[45986] = false, -- Tiny Titanium Lockbox
-	[43624] = false, -- Titanium Lockbox
-	[51316] = true, -- Unsealed Chest
-	[43504] = true, -- Winter Veil Gift
-	[46740] = true, -- Winter Veil Gift
-}
-
---------------------------------------------------------------------------------
--- Ignore List
---------------------------------------------------------------------------------
-
--- { [itemId] = true }
--- Hand-curated by item ID; no source query.
-
-ns.IgnoreItems = {
-
-	--------------------------------------------------------------------------------
-	-- 01. World of Warcraft
-	--------------------------------------------------------------------------------
-
-	[17962] = true, -- Blue Sack of Gems
-	[21812] = true, -- Box of Chocolates
-	[8049] = true, -- Gnarlpine Necklace
-	[17964] = true, -- Gray Sack of Gems
-	[17963] = true, -- Green Sack of Gems
-	[9276] = true, -- Pirate's Footlocker
-	[17969] = true, -- Red Sack of Gems
-	[17965] = true, -- Yellow Sack of Gems
-
-	--------------------------------------------------------------------------------
-	-- 02. World of Warcraft: The Burning Crusade
-	--------------------------------------------------------------------------------
-
-	[191060] = true, -- Black Sack of Gems
-	[34846] = true, -- Black Sack of Gems
-
-	--------------------------------------------------------------------------------
-	-- 03. World of Warcraft: Wrath of the Lich King
-	--------------------------------------------------------------------------------
-
-	[46110] = true, -- Alchemist's Cache
-	[49294] = true, -- Ashen Sack of Gems
-	[43346] = true, -- Large Satchel of Spoils
-	[43347] = true, -- Satchel of Spoils
 }

--- a/Data/Default-Settings.lua
+++ b/Data/Default-Settings.lua
@@ -5,21 +5,256 @@ local _, ns = ...
 --------------------------------------------------------------------------------
 
 --[[
-    AceDB-3.0 defaults. Every user setting lives under `profile`; `global` holds
-    only the minimap position, which is account-wide and profile-independent so
-    switching or resetting profiles never moves the button. Core.lua hands this
+    AceDB-3.0 defaults. Open Sesame uses the Simple saved-variables model — one
+    shared profile for every character — so everything lives under `profile`,
+    the mini-map subtable included, and `global` is unused. Core.lua hands this
     table to AceDB:New, which applies defaults via metatables — no hand-merge.
 ]]
 ns.DATABASE_DEFAULTS = {
 	profile = {
 		autoOpen = true,
+		-- "ALWAYS" | "OUTSIDE_INSTANCES"
+		autoOpenWhere = "ALWAYS",
+		-- "ALWAYS" | "SOLO_ONLY"
+		autoOpenGroup = "ALWAYS",
 		speedyLoot = true,
+		lockboxTooltips = true,
+		-- "ROGUES" | "ALL"
+		lockboxTooltipsScope = "ROGUES",
 		lootSounds = true,
 		lootSoundThreshold = 2,
+		-- Rogues only in practice; nothing else can cast Pick Pocket.
+		pickPocketSound = true,
+		lootToasts = true,
+		--[[
+            Whether this profile has been shown the drag handle and put it away.
+            Per profile, not account-wide, on purpose: a new or reset profile is
+            one that has not been introduced to the feature, and should be.
+        ]]
+		lootToastsIntroSeen = false,
+		--[[
+            Poor: everything the player loots gets a row. The toast stack stands
+            in for the loot window Speedy Loot hides, and a window shows you what
+            you picked up whatever colour it was. The loot SOUND keeps its
+            Uncommon threshold above, because a sound is an interruption and a row
+            is a record - one wants to be rare, the other wants to be complete.
+
+            At this setting the always-shown kinds below have nothing left to do;
+            they are there for the player who raises the threshold, and that is
+            the moment they earn their place.
+        ]]
+		lootToastThreshold = 0,
+		--[[
+            All eight ignore the threshold above, and all eight ship on: each is a
+            kind whose worth has nothing to do with its colour, so a threshold set
+            high enough to quiet the noise would hide exactly the pickups a player
+            wants to see. Bind on Pickup is the broad one - it catches the keeps
+            the named kinds miss. Listed here in the order the options panel shows
+            them, which is the player's order, not the order they are tested in.
+        ]]
+		lootToastBindOnPickup = true,
+		lootToastQuestItems = true,
+		lootToastRecipes = true,
+		lootToastMounts = true,
+		lootToastPets = true,
+		lootToastKeys = true,
+		lootToastBags = true,
+		lootToastContainers = true,
+		-- Not a threshold bypass: coin has no quality to be measured against.
+		lootToastMoney = true,
+		lootToastDuration = 5,
+		lootToastMaxVisible = 8,
+		-- "UP" | "DOWN"
+		lootToastGrowth = "UP",
+		-- "LEFT" | "RIGHT"
+		lootToastAlign = "LEFT",
+		lootToastFont = "DEFAULT",
+		lootToastFontSize = 16,
+		-- One of ns.LOOT_TOAST_FONT_FLAGS.
+		lootToastFontFlags = "OUTLINE",
 		showWelcome = true,
 		lockboxNotifications = true,
-	},
-	global = {
+		-- "ROGUES" | "ALL"
+		lockboxNotificationsScope = "ROGUES",
+		ignoreListNotifications = true,
 		minimap = {},
 	},
+	--[[
+        The Ignore List is deliberately account-wide: the containers a player
+        hoards are a decision about the items, not about the character, so it
+        must not move or reset with a profile.
+    ]]
+	global = {
+		ignoreList = {},
+		lootToastPosition = {},
+	},
+}
+
+--------------------------------------------------------------------------------
+-- Default Ignore List
+--------------------------------------------------------------------------------
+
+--[[
+    The list the player's Ignore List is seeded from on first login and rebuilt
+    from by Restore Defaults. The live list is ns.db.global.ignoreList; nothing
+    reads this table directly. Shipping new entries here does not change an
+    existing player's saved list, so note additions in the release notes.
+]]
+
+--[[
+    REGENERATING THIS TABLE TAKES TWO SOURCES AND A HAND EDIT. Running the query
+    below on its own does NOT reproduce what ships here - see the three notes at
+    the end before replacing anything.
+
+    Source 1, CMaNGOS (Wrath) world DB, decides WHICH containers and WHY. Two
+    rules put a container on the list:
+
+      * It drops from a raid boss (creature_template.rank = 3). Those are sold
+        unopened in GDKP runs, so opening one destroys the reason to keep it.
+        This branch deliberately ignores the container's own bonding: the DB has
+        Blue Sack of Gems as Bind on Pickup while its four siblings are
+        tradeable, which is a data quirk rather than a real difference.
+      * It is a tradeable container holding a non-quest Bind on Pickup item.
+        Opening it binds that item to you, destroying something sellable.
+
+    Each clause earns its place:
+      loot.bonding = 1            the loot binds on pickup
+      loot.class <> 12            quest items are not a reason to hold off
+      loot.startquest = 0         nor are quest starters
+      c.bonding NOT IN (1, 4)     a container that is itself soulbound or a quest
+                                  item could never be traded, so opening it costs
+                                  nothing. Bind on Equip and Bind on Use stay in:
+                                  a container is never equipped, and for Bind on
+                                  Use, opening IS the use that binds it
+      c.lockid = 0                never a lockbox, those are what the add-on opens
+      c.name NOT LIKE 'Test %'    GM/debug items that never reach a player
+
+    Unique is NOT a criterion. An early version used maxcount > 0 and produced
+    144 rows instead of 35, because nearly every quest item and one-off trinket
+    is Unique. Do not add it back.
+
+    Source 2, WOWHEAD's per-client openable listings, decides the EXPANSION TAG
+    and supplies ids the world DB has never heard of. See Data/Openable-Items.lua
+    for the fuller account; the same three listings feed both tables.
+
+    SQL comments here are /* block */ form on purpose: a -- comment runs to end of
+    line, so any client that folds the statement onto one line would swallow the
+    rest of the query and leave the parenthesis unclosed.
+
+    WITH RECURSIVE
+    loot_contents (container, ref_entry, item_entry) AS (
+        SELECT ilt.entry,
+               IF(ilt.mincountOrRef < 0, -ilt.mincountOrRef, NULL),
+               IF(ilt.mincountOrRef > 0, ilt.item, NULL)
+        FROM item_loot_template ilt
+        UNION ALL
+        SELECT lc.container,
+               IF(rlt.mincountOrRef < 0, -rlt.mincountOrRef, NULL),
+               IF(rlt.mincountOrRef > 0, rlt.item, NULL)
+        FROM loot_contents lc
+        JOIN reference_loot_template rlt ON rlt.entry = lc.ref_entry
+        WHERE lc.ref_entry IS NOT NULL
+    ),
+    raid_drop (item_entry) AS (
+        SELECT DISTINCT clt.item
+        FROM creature_loot_template clt
+        JOIN creature_template ct ON ct.entry = clt.entry
+        WHERE ct.rank = 3 AND clt.mincountOrRef > 0
+        UNION
+        SELECT DISTINCT rlt.item
+        FROM creature_loot_template clt
+        JOIN creature_template ct ON ct.entry = clt.entry
+        JOIN reference_loot_template rlt ON rlt.entry = -clt.mincountOrRef
+        WHERE ct.rank = 3 AND clt.mincountOrRef < 0 AND rlt.mincountOrRef > 0
+    )
+    SELECT CONCAT('\t[', t.entry, '] = { EXPANSION, "', t.reason, '" }, -- ', t.name) AS lua_row
+    FROM (
+        SELECT c.entry, c.name,
+               CASE
+                   WHEN EXISTS (SELECT 1 FROM raid_drop rd WHERE rd.item_entry = c.entry) THEN 'RAID'
+                   WHEN MAX(loot.HolidayId <> 0) = 1 THEN 'HOLIDAY'
+                   WHEN MAX(loot.class = 9) = 1 THEN 'RECIPE'
+                   WHEN MAX(loot.class IN (2, 4)) = 1 THEN 'GEAR'
+                   ELSE 'ITEM'
+               END AS reason
+        FROM loot_contents lc
+        JOIN item_template c    ON c.entry = lc.container
+        JOIN item_template loot ON loot.entry = lc.item_entry
+        WHERE c.lockid = 0
+          AND c.name NOT LIKE 'Test %'
+          AND (
+              EXISTS (SELECT 1 FROM raid_drop rd WHERE rd.item_entry = c.entry)
+              OR (loot.bonding = 1 AND loot.class <> 12 AND loot.startquest = 0
+                  AND c.bonding NOT IN (1, 4))
+          )
+        GROUP BY c.entry, c.name
+    ) t
+    ORDER BY t.name;
+
+    THREE THINGS THE QUERY DOES NOT PRODUCE, all of which ship here:
+
+      1. The EXPANSION tag. It emits the literal EXPANSION as a placeholder; the
+         real value comes from Wowhead availability (see Openable-Items.lua).
+      2. Re-added ids under a name the query already returns - 191060 Black Sack
+         of Gems is the current example. Wowhead carries them, the Wrath DB does
+         not. They inherit the reason of the row sharing their name.
+      3. The two rows marked "hand-added" in their comment: Gnarlpine Necklace
+         and Pirate's Footlocker. Both hold only quest loot and neither is a raid
+         drop, so no rule reaches them; they are on the list by maintainer
+         decision and carry the QUEST reason.
+]]
+
+-- { [itemId] = { expansionThatAddedIt, reasonKey } } -- Container (the BoP loot)
+
+ns.DEFAULT_IGNORE_ITEMS = {
+
+	--------------------------------------------------------------------------------
+	-- 01. World of Warcraft
+	--------------------------------------------------------------------------------
+
+	[17962] = { ns.VANILLA, "RAID" }, -- Blue Sack of Gems (Azuregos, Kazzak, the dragons, Nefarian)
+	[11937] = { ns.VANILLA, "GEAR" }, -- Fat Sack of Coins (Fire Opal Necklace)
+	[21979] = { ns.VANILLA, "HOLIDAY" }, -- Gift of Adoration: Darnassus (Love is in the Air gifts)
+	[21980] = { ns.VANILLA, "HOLIDAY" }, -- Gift of Adoration: Ironforge (Love is in the Air gifts)
+	[22164] = { ns.VANILLA, "HOLIDAY" }, -- Gift of Adoration: Orgrimmar (Love is in the Air gifts)
+	[21981] = { ns.VANILLA, "HOLIDAY" }, -- Gift of Adoration: Stormwind (Love is in the Air gifts)
+	[22165] = { ns.VANILLA, "HOLIDAY" }, -- Gift of Adoration: Thunder Bluff (Love is in the Air gifts)
+	[22166] = { ns.VANILLA, "HOLIDAY" }, -- Gift of Adoration: Undercity (Love is in the Air gifts)
+	[8049] = { ns.VANILLA, "QUEST" }, -- Gnarlpine Necklace (hand-added: Tallonkai's Jewel)
+	[17964] = { ns.VANILLA, "RAID" }, -- Gray Sack of Gems (Azuregos, Kazzak, the dragons, Nefarian)
+	[17963] = { ns.VANILLA, "RAID" }, -- Green Sack of Gems (Azuregos, Kazzak, the dragons, Nefarian)
+	[13874] = { ns.VANILLA, "RAID" }, -- Heavy Crate (Gahz'ranka)
+	[21150] = { ns.VANILLA, "RECIPE" }, -- Iron Bound Trunk (Weather-Beaten Journal)
+	[21228] = { ns.VANILLA, "RECIPE" }, -- Mithril Bound Trunk (Weather-Beaten Journal)
+	[9276] = { ns.VANILLA, "QUEST" }, -- Pirate's Footlocker (hand-added: Ship Schedule, map fragments)
+	[22155] = { ns.VANILLA, "HOLIDAY" }, -- Pledge of Adoration: Darnassus (Love is in the Air gifts)
+	[22154] = { ns.VANILLA, "HOLIDAY" }, -- Pledge of Adoration: Ironforge (Love is in the Air gifts)
+	[22156] = { ns.VANILLA, "HOLIDAY" }, -- Pledge of Adoration: Orgrimmar (Love is in the Air gifts)
+	[21975] = { ns.VANILLA, "HOLIDAY" }, -- Pledge of Adoration: Stormwind (Love is in the Air gifts)
+	[22158] = { ns.VANILLA, "HOLIDAY" }, -- Pledge of Adoration: Thunder Bluff (Love is in the Air gifts)
+	[22157] = { ns.VANILLA, "HOLIDAY" }, -- Pledge of Adoration: Undercity (Love is in the Air gifts)
+	[17969] = { ns.VANILLA, "RAID" }, -- Red Sack of Gems (Azuregos, Kazzak, the dragons, Nefarian)
+	[20767] = { ns.VANILLA, "RECIPE" }, -- Scum Covered Bag (Plans: Wicked Mithril Blade)
+	[20708] = { ns.VANILLA, "RECIPE" }, -- Tightly Sealed Trunk (Weather-Beaten Journal)
+	[6352] = { ns.VANILLA, "GEAR" }, -- Waterlogged Crate (Hammer of the Vesper)
+	[21113] = { ns.VANILLA, "RECIPE" }, -- Watertight Trunk (Weather-Beaten Journal)
+	[17965] = { ns.VANILLA, "RAID" }, -- Yellow Sack of Gems (Azuregos, Kazzak, the dragons, Nefarian)
+
+	--------------------------------------------------------------------------------
+	-- 02. World of Warcraft : The Burning Crusade
+	--------------------------------------------------------------------------------
+
+	[34846] = { ns.TBC, "RAID" }, -- Black Sack of Gems (Magtheridon)
+	[191060] = { ns.TBC, "RAID" }, -- Black Sack of Gems (Magtheridon, same name)
+	[34548] = { ns.TBC, "RECIPE" }, -- Cache of the Shattered Sun (11 Designs, Patterns and Plans)
+	[27513] = { ns.TBC, "RECIPE" }, -- Curious Crate (Weather-Beaten Journal)
+	[27481] = { ns.TBC, "RECIPE" }, -- Heavy Supply Crate (Weather-Beaten Journal)
+
+	--------------------------------------------------------------------------------
+	-- 03. World of Warcraft : Wrath of the Lich King
+	--------------------------------------------------------------------------------
+
+	[49294] = { ns.WRATH, "RAID" }, -- Ashen Sack of Gems (Onyxia)
+	[43346] = { ns.WRATH, "RAID" }, -- Large Satchel of Spoils (Sartharion)
+	[43347] = { ns.WRATH, "RAID" }, -- Satchel of Spoils (Sartharion)
 }

--- a/Data/Openable-Items.lua
+++ b/Data/Openable-Items.lua
@@ -1,0 +1,561 @@
+local _, ns = ...
+
+--------------------------------------------------------------------------------
+-- Openable Items
+--------------------------------------------------------------------------------
+
+--[[
+    Which containers Open Sesame may open. Split out of Data.lua because this is
+    a large generated table rather than the hand-set constants that file holds,
+    and it is regenerated from a different source.
+
+    Keyed by item ID and sorted by item NAME within each expansion block, which
+    is the order the query below emits.
+]]
+
+--[[
+    REGENERATING THIS TABLE TAKES TWO SOURCES. The query below reproduces roughly
+    three quarters of it; the rest exists only because of the second source, so
+    never replace this table with query output alone.
+
+    SOURCE 1 - CMaNGOS (Wrath) world DB - answers WHICH KIND a container is. An
+    item is openable when it has loot rows of its own in item_loot_template, and
+    lockid separates the two kinds: 0 means it opens on sight, anything else means
+    it must be unlocked first. That is exactly the true/false stored here.
+
+    SELECT CONCAT('\t[', it.entry, '] = ', IF(it.lockid = 0, 'true', 'false'), ', -- ', it.name) AS lua_row
+    FROM item_template it
+    WHERE EXISTS (SELECT 1 FROM item_loot_template ilt WHERE ilt.entry = it.entry)
+    ORDER BY it.name;
+
+    SOURCE 2 - WOWHEAD's per-client openable-item listings, one per flavour
+    (Classic Era including Season of Discovery, Burning Crusade, Wrath), exported
+    as id + name. These answer two things the world DB cannot:
+
+      * WHICH CLIENTS HAVE IT, which is the entire basis of the expansion blocks.
+        An id present on Era sits in block 01, one first appearing in TBC in block
+        02, one only in Wrath in block 03. Do not go back to guessing this from id
+        ranges: six-digit modern Classic re-adds break any range rule.
+      * THE ITEMS A WRATH DB HAS NEVER HEARD OF - modern Classic re-adds and every
+        Season of Discovery container. Roughly 128 rows here came from Wowhead
+        alone and would vanish if this table were rebuilt from SQL only.
+
+    The world DB is also missing things Wowhead has for a different reason: clams
+    and the Lotteryboxes deliver loot through a spell rather than
+    item_loot_template, so the query never returns them.
+
+    MERGE RULES, applied when the two sources are combined:
+
+      * Placeholder rows are dropped: names beginning "Test ", "[DNT]", "[PH]" or
+        "QATest" are GM and debug items no player ever sees.
+      * A re-added id inherits the true/false of the existing row with the same
+        name. The Anniversary client renumbers items without changing what they
+        are, so the name is the reliable key.
+      * Failing that, a name carrying "Lockbox", "Junkbox" or "Locked Chest" is
+        taken as needing an unlock. Only two rows rest on that guess today:
+        Dark Iron Lockbox (208838) and Scarlet Junkbox (239248).
+
+    Data/Default-Settings.lua's ns.DEFAULT_IGNORE_ITEMS is generated from the same
+    two sources and carries its own regeneration notes.
+]]
+
+-- { [itemId] = canOpenImmediately (true) or requiresUnlock (false) }
+
+ns.AllowedItems = {
+
+	--------------------------------------------------------------------------------
+	-- 01. World of Warcraft
+	--------------------------------------------------------------------------------
+
+	[10456] = true, -- A Bulging Coin Purse
+	[15902] = true, -- A Crazy Grab Bag
+	[11883] = true, -- A Dingy Fanny Pack
+	[5335] = true, -- A Sack of Coins
+	[6755] = true, -- A Small Container of Gems
+	[11107] = true, -- A Small Pack
+	[205364] = true, -- Acolyte's Knapsack
+	[208223] = true, -- Acolyte's Knapsack
+	[21509] = true, -- Ahn'Qiraj War Effort Supplies
+	[21510] = true, -- Ahn'Qiraj War Effort Supplies
+	[21511] = true, -- Ahn'Qiraj War Effort Supplies
+	[21512] = true, -- Ahn'Qiraj War Effort Supplies
+	[21513] = true, -- Ahn'Qiraj War Effort Supplies
+	[22152] = true, -- Anthion's Pouch
+	[20231] = true, -- Arathor Advanced Care Package
+	[20233] = true, -- Arathor Basic Care Package
+	[20236] = true, -- Arathor Standard Care Package
+	[227360] = true, -- Astral Boots Legs and Shoulders Set
+	[227338] = true, -- Astral Gloves and Belt Set
+	[227384] = true, -- Astral Helm and Chestpiece Set
+	[11955] = true, -- Bag of Empty Ooze Containers
+	[20603] = true, -- Bag of Spoils
+	[6356] = true, -- Battered Chest
+	[16882] = false, -- Battered Junkbox
+	[227374] = true, -- Battle's Boots Legs and Shoulders Set
+	[227349] = true, -- Battle's Gloves and Belt Set
+	[227396] = true, -- Battle's Helm and Chestpiece Set
+	[7973] = true, -- Big-mouth Clam
+	[6646] = true, -- Bloated Albacore
+	[6647] = true, -- Bloated Catfish
+	[21163] = true, -- Bloated Firefin
+	[6644] = true, -- Bloated Mackerel
+	[21243] = true, -- Bloated Mightfish
+	[6645] = true, -- Bloated Mud Snapper
+	[21162] = true, -- Bloated Oily Blackmouth
+	[13881] = true, -- Bloated Redgill
+	[21164] = true, -- Bloated Rockscale Cod
+	[13891] = true, -- Bloated Salmon
+	[6643] = true, -- Bloated Smallfish
+	[8366] = true, -- Bloated Trout
+	[17962] = true, -- Blue Sack of Gems
+	[21812] = true, -- Box of Chocolates
+	[10695] = true, -- Box of Empty Vials
+	[213641] = true, -- Box of Gnomeregan Salvage
+	[9541] = true, -- Box of Goodies
+	[9539] = true, -- Box of Rations
+	[9540] = true, -- Box of Spells
+	[6827] = true, -- Box of Supplies
+	[220914] = true, -- Broken Geode Hammer
+	[8502] = true, -- Bronze Lotterybox
+	[22746] = true, -- Buccaneer's Uniform
+	[16783] = true, -- Bundle of Reports
+	[216618] = true, -- Captain Aransas' Reward
+	[21191] = true, -- Carefully Wrapped Present
+	[11887] = true, -- Cenarion Circle Cache
+	[20602] = true, -- Chest of Spoils
+	[21741] = true, -- Cluster Rocket Recipes
+	[21528] = true, -- Colossal Bag of Loot
+	[20808] = true, -- Combat Assignment
+	[227379] = true, -- Corrupted Boots Legs and Shoulders Set
+	[227354] = true, -- Corrupted Gloves and Belt Set
+	[227401] = true, -- Corrupted Helm and Chestpiece Set
+	[5738] = true, -- Covert Ops Pack
+	[208848] = true, -- Cracked Skull-Shaped Geode
+	[9265] = true, -- Cuergo's Hidden Treasure
+	[23022] = true, -- Curmudgeon's Payoff
+	[236414] = true, -- Damaged Undermine Supply Crate
+	[226405] = true, -- Damaged Undermine Supply Crate
+	[208838] = false, -- Dark Iron Lockbox
+	[19422] = true, -- Darkmoon Faire Fortune
+	[227371] = true, -- Dawn Boots Legs and Shoulders Set
+	[227346] = true, -- Dawn Gloves and Belt Set
+	[227393] = true, -- Dawn Helm and Chestpiece Set
+	[191656] = true, -- Death's Essence
+	[20469] = true, -- Decoded True Believer Clippings
+	[20228] = true, -- Defiler's Advanced Care Package
+	[20229] = true, -- Defiler's Basic Care Package
+	[20230] = true, -- Defiler's Standard Care Package
+	[12849] = true, -- Demon Kissed Sack
+	[6351] = true, -- Dented Crate
+	[209031] = true, -- Discreet Envelope
+	[227370] = true, -- Divine Will Boots Legs and Shoulders Set
+	[227345] = true, -- Divine Will Gloves and Belt Set
+	[227392] = true, -- Divine Will Helm and Chestpiece Set
+	[238681] = true, -- Dusty Bag
+	[8647] = true, -- Egg Crate
+	[10752] = true, -- Emerald Encrusted Chest
+	[221471] = true, -- Emerald Wardens Chest
+	[213565] = true, -- Entomology Starter Kit
+	[11617] = true, -- Eridan's Supplies
+	[227376] = true, -- Eruption's Boots Legs and Shoulders Set
+	[227351] = true, -- Eruption's Gloves and Belt Set
+	[227398] = true, -- Eruption's Helm and Chestpiece Set
+	[5760] = false, -- Eternium Lockbox
+	[11024] = true, -- Evergreen Herb Casing
+	[215465] = true, -- Exploded Strongbox
+	[11937] = true, -- Fat Sack of Coins
+	[10834] = true, -- Felhound Tracker Kit
+	[227359] = true, -- Feline Boots Legs and Shoulders Set
+	[227337] = true, -- Feline Gloves and Belt Set
+	[227383] = true, -- Feline Helm and Chestpiece Set
+	[21363] = true, -- Festive Gift
+	[189421] = true, -- Fire Resist Leather Gear
+	[189419] = true, -- Fire Resist Plate Gear
+	[189420] = true, -- Fire Resist Plate Gear
+	[21131] = true, -- Followup Combat Assignment
+	[20805] = true, -- Followup Logistics Assignment
+	[21386] = true, -- Followup Logistics Assignment
+	[21133] = true, -- Followup Tactical Assignment
+	[8484] = true, -- Gadgetzan Water Co. Care Package
+	[21310] = true, -- Gaily Wrapped Present
+	[21270] = true, -- Gently Shaken Gift
+	[21271] = true, -- Gently Shaken Gift
+	[21979] = true, -- Gift of Adoration: Darnassus
+	[21980] = true, -- Gift of Adoration: Ironforge
+	[22164] = true, -- Gift of Adoration: Orgrimmar
+	[21981] = true, -- Gift of Adoration: Stormwind
+	[22165] = true, -- Gift of Adoration: Thunder Bluff
+	[22166] = true, -- Gift of Adoration: Undercity
+	[22167] = true, -- Gift of Friendship: Darnassus
+	[22168] = true, -- Gift of Friendship: Ironforge
+	[22169] = true, -- Gift of Friendship: Orgrimmar
+	[22170] = true, -- Gift of Friendship: Stormwind
+	[22171] = true, -- Gift of Friendship: Thunder Bluff
+	[22172] = true, -- Gift of Friendship: Undercity
+	[8049] = true, -- Gnarlpine Necklace
+	[11423] = true, -- Gnome Engineer's Renewal Gift
+	[5857] = true, -- Gnome Prize Box
+	[11422] = true, -- Goblin Engineer's Renewal Gift
+	[5858] = true, -- Goblin Prize Box
+	[17964] = true, -- Gray Sack of Gems
+	[19296] = true, -- Greater Darkmoon Prize
+	[17963] = true, -- Green Sack of Gems
+	[227361] = true, -- Guardian's Boots Legs and Shoulders Set
+	[227339] = true, -- Guardian's Gloves and Belt Set
+	[227385] = true, -- Guardian's Helm and Chestpiece Set
+	[10773] = true, -- Hakkari Urn
+	[4633] = false, -- Heavy Bronze Lockbox
+	[8503] = true, -- Heavy Bronze Lotterybox
+	[13874] = true, -- Heavy Crate
+	[8505] = true, -- Heavy Iron Lotterybox
+	[16885] = false, -- Heavy Junkbox
+	[8507] = true, -- Heavy Mithril Lotterybox
+	[208766] = true, -- Helping Hand
+	[227931] = true, -- Hidden Bundle
+	[22648] = true, -- Hive'Ashi Dossier
+	[22649] = true, -- Hive'Regal Dossier
+	[22650] = true, -- Hive'Zora Dossier
+	[10569] = true, -- Hoard of the Black Dragonflight
+	[210330] = true, -- Hot Tip
+	[20367] = true, -- Hunting Gear
+	[227381] = true, -- Immoveable Boots Legs and Shoulders Set
+	[227356] = true, -- Immoveable Gloves and Belt Set
+	[227403] = true, -- Immoveable Helm and Chestpiece Set
+	[227377] = true, -- Impact's Boots Legs and Shoulders Set
+	[227352] = true, -- Impact's Gloves and Belt Set
+	[227399] = true, -- Impact's Helm and Chestpiece Set
+	[9529] = true, -- Internal Warrior Equipment Kit L25
+	[9532] = true, -- Internal Warrior Equipment Kit L30
+	[21150] = true, -- Iron Bound Trunk
+	[4634] = false, -- Iron Lockbox
+	[8504] = true, -- Iron Lotterybox
+	[13875] = false, -- Ironbound Locked Chest
+	[212553] = true, -- Jewel-Encrusted Box
+	[221371] = true, -- Kidnapper's Coin Purse
+	[10479] = true, -- Kovic's Trading Satchel
+	[10595] = true, -- Kum'isha's Junk
+	[12122] = true, -- Kum'isha's Junk
+	[19035] = true, -- Lard's Special Picnic Basket
+	[21743] = true, -- Large Cluster Rocket Recipes
+	[21742] = true, -- Large Rocket Recipes
+	[215451] = true, -- Large Strongbox
+	[19297] = true, -- Lesser Darkmoon Prize
+	[21132] = true, -- Logistics Assignment
+	[21266] = true, -- Logistics Assignment
+	[18804] = true, -- Lord Grayson's Satchel
+	[21746] = true, -- Lucky Red Envelope
+	[21640] = true, -- Lunar Festival Fireworks Pack
+	[215452] = true, -- Medium Strongbox
+	[227365] = true, -- Mender's Boots Legs and Shoulders Set
+	[227340] = true, -- Mender's Gloves and Belt Set
+	[227387] = true, -- Mender's Helm and Chestpiece Set
+	[227368] = true, -- Merciful Boots Legs and Shoulders Set
+	[227343] = true, -- Merciful Gloves and Belt Set
+	[227390] = true, -- Merciful Helm and Chestpiece Set
+	[6307] = true, -- Message in a Bottle
+	[19298] = true, -- Minor Darkmoon Prize
+	[219773] = true, -- Mission Brief: Ashenvale
+	[219526] = true, -- Mission Brief: Duskwood
+	[219775] = true, -- Mission Brief: Feralas
+	[219774] = true, -- Mission Brief: Hinterlands
+	[21228] = true, -- Mithril Bound Trunk
+	[5758] = false, -- Mithril Lockbox
+	[8506] = true, -- Mithril Lotterybox
+	[189427] = true, -- More Raid Consumables
+	[22320] = true, -- Mux's Quality Goods
+	[19425] = true, -- Mysterious Lockbox
+	[21042] = true, -- Narain's Special Kit
+	[15876] = true, -- Nathanos' Chest
+	[9537] = true, -- Neatly Wrapped Box
+	[20768] = true, -- Oozing Bag
+	[4632] = false, -- Ornate Bronze Lockbox
+	[228615] = true, -- Otherworldly Treasure
+	[220446] = true, -- Otherworldly Treasure
+	[224836] = true, -- Otherworldly Treasure
+	[224848] = true, -- Otherworldly Treasure
+	[224850] = true, -- Otherworldly Treasure
+	[224851] = true, -- Otherworldly Treasure
+	[224849] = true, -- Otherworldly Treasure
+	[223148] = true, -- Otherworldly Treasure
+	[223149] = true, -- Otherworldly Treasure
+	[223150] = true, -- Otherworldly Treasure
+	[223151] = true, -- Otherworldly Treasure
+	[19153] = true, -- Outrider Advanced Care Package
+	[19154] = true, -- Outrider Basic Care Package
+	[19155] = true, -- Outrider Standard Care Package
+	[11912] = true, -- Package of Empty Ooze Containers
+	[9276] = true, -- Pirate's Footlocker
+	[22155] = true, -- Pledge of Adoration: Darnassus
+	[22154] = true, -- Pledge of Adoration: Ironforge
+	[22156] = true, -- Pledge of Adoration: Orgrimmar
+	[21975] = true, -- Pledge of Adoration: Stormwind
+	[22158] = true, -- Pledge of Adoration: Thunder Bluff
+	[22157] = true, -- Pledge of Adoration: Undercity
+	[22159] = true, -- Pledge of Friendship: Darnassus
+	[22160] = true, -- Pledge of Friendship: Ironforge
+	[22161] = true, -- Pledge of Friendship: Orgrimmar
+	[22178] = true, -- Pledge of Friendship: Stormwind
+	[22162] = true, -- Pledge of Friendship: Thunder Bluff
+	[22163] = true, -- Pledge of Friendship: Undercity
+	[227367] = true, -- Prowler's Boots Legs and Shoulders Set
+	[227342] = true, -- Prowler's Gloves and Belt Set
+	[227389] = true, -- Prowler's Helm and Chestpiece Set
+	[227366] = true, -- Pursuer's Boots Legs and Shoulders Set
+	[227341] = true, -- Pursuer's Gloves and Belt Set
+	[227388] = true, -- Pursuer's Helm and Chestpiece Set
+	[227937] = true, -- Puzzle Box
+	[13247] = true, -- Quartermaster Zigris' Footlocker
+	[227369] = true, -- Radiant Boots Legs and Shoulders Set
+	[227344] = true, -- Radiant Gloves and Belt Set
+	[227391] = true, -- Radiant Helm and Chestpiece Set
+	[189426] = true, -- Raid Consumables
+	[17969] = true, -- Red Sack of Gems
+	[13918] = false, -- Reinforced Locked Chest
+	[4638] = false, -- Reinforced Steel Lockbox
+	[227375] = true, -- Relief's Boots Legs and Shoulders Set
+	[227350] = true, -- Relief's Gloves and Belt Set
+	[227397] = true, -- Relief's Helm and Chestpiece Set
+	[227378] = true, -- Resolve's Boots Legs and Shoulders Set
+	[227353] = true, -- Resolve's Gloves and Belt Set
+	[227400] = true, -- Resolve's Helm and Chestpiece Set
+	[6715] = true, -- Ruined Jumper Cables
+	[18636] = true, -- Ruined Jumper Cables XL
+	[11938] = true, -- Sack of Gems
+	[20601] = true, -- Sack of Spoils
+	[211799] = true, -- Sack of Stolen Goods
+	[235144] = true, -- Satchel of Blood-Caked Copper Coins
+	[235145] = true, -- Satchel of Blood-Caked Silver Coins
+	[216971] = true, -- Satchel of Copper Blood Coins
+	[221367] = true, -- Satchel of Copper Massacre Coins
+	[228326] = true, -- Satchel of Copper Slaughter Coins
+	[216972] = true, -- Satchel of Silver Blood Coins
+	[221368] = true, -- Satchel of Silver Massacre Coins
+	[228327] = true, -- Satchel of Silver Slaughter Coins
+	[21156] = true, -- Scarab Bag
+	[239248] = false, -- Scarlet Junkbox
+	[7190] = true, -- Scorched Rocket Boots
+	[20767] = true, -- Scum Covered Bag
+	[22568] = true, -- Sealed Craftsman's Writ
+	[6357] = true, -- Sealed Crate
+	[19152] = true, -- Sentinel Advanced Care Package
+	[19150] = true, -- Sentinel Basic Care Package
+	[19151] = true, -- Sentinel Standard Care Package
+	[221491] = true, -- Shadowtooth Bag
+	[20766] = true, -- Slimy Bag
+	[5523] = true, -- Small Barnacled Clam
+	[15699] = true, -- Small Brown-wrapped Package
+	[6353] = true, -- Small Chest
+	[6354] = false, -- Small Locked Chest
+	[21740] = true, -- Small Rocket Recipes
+	[11966] = true, -- Small Sack of Coins
+	[215453] = true, -- Small Strongbox
+	[21216] = true, -- Smokywood Pastures Extra-Special Gift
+	[17727] = true, -- Smokywood Pastures Gift Pack
+	[17685] = true, -- Smokywood Pastures Sampler
+	[17726] = true, -- Smokywood Pastures Special Gift
+	[21315] = true, -- Smokywood Satchel
+	[15874] = true, -- Soft-shelled Clam
+	[9363] = true, -- Sparklematic-Wrapped Box
+	[4637] = false, -- Steel Lockbox
+	[11442] = true, -- Stormwind Deputy Kit
+	[4636] = false, -- Strong Iron Lockbox
+	[16884] = false, -- Sturdy Junkbox
+	[6355] = false, -- Sturdy Locked Chest
+	[23224] = true, -- Summer Gift Package
+	[237263] = true, -- Supply Bag
+	[217014] = true, -- Supply Bag
+	[20809] = true, -- Tactical Assignment
+	[7209] = false, -- Tazan's Satchel
+	[7870] = true, -- Thaumaturgy Vessel Lockbox
+	[12033] = false, -- Thaurissan Family Jewels
+	[5524] = true, -- Thick-shelled Clam
+	[7868] = false, -- Thieven' Kit
+	[5759] = false, -- Thorium Lockbox
+	[227373] = true, -- Thrill's Boots Legs and Shoulders Set
+	[227348] = true, -- Thrill's Gloves and Belt Set
+	[227395] = true, -- Thrill's Helm and Chestpiece Set
+	[213443] = true, -- Ticking Present
+	[21327] = true, -- Ticking Present
+	[20708] = true, -- Tightly Sealed Trunk
+	[215454] = true, -- Tiny Strongbox
+	[11568] = true, -- Torwa's Pouch
+	[20393] = true, -- Treat Bag
+	[227372] = true, -- Twilight Boots Legs and Shoulders Set
+	[227347] = true, -- Twilight Gloves and Belt Set
+	[227394] = true, -- Twilight Helm and Chestpiece Set
+	[227382] = true, -- Unstoppable Boots Legs and Shoulders Set
+	[227357] = true, -- Unstoppable Gloves and Belt Set
+	[227404] = true, -- Unstoppable Helm and Chestpiece Set
+	[12339] = true, -- Vaelan's Gift
+	[231644] = true, -- Warden's Enchanting Bag
+	[231642] = true, -- Warden's Herb Bag
+	[237386] = true, -- Wartorn Undermine Supply Crate
+	[6352] = true, -- Waterlogged Crate
+	[21113] = true, -- Watertight Trunk
+	[227380] = true, -- Wicked Boots Legs and Shoulders Set
+	[227355] = true, -- Wicked Gloves and Belt Set
+	[227402] = true, -- Wicked Helm and Chestpiece Set
+	[16883] = false, -- Worn Junkbox
+	[17965] = true, -- Yellow Sack of Gems
+	[22137] = true, -- Ysida's Satchel
+	[22233] = true, -- Zigris' Footlocker
+	[216646] = true, -- Ziri's Mystery Crate
+
+	--------------------------------------------------------------------------------
+	-- 02. World of Warcraft : The Burning Crusade
+	--------------------------------------------------------------------------------
+
+	[34583] = true, -- Aldor Supplies Package
+	[34587] = true, -- Aldor Supplies Package
+	[34592] = true, -- Aldor Supplies Package
+	[34595] = true, -- Aldor Supplies Package
+	[28499] = true, -- Arakkoa Hunter's Supplies
+	[31955] = true, -- Arelion's Knapsack
+	[35348] = true, -- Bag of Fishing Treasures
+	[34863] = true, -- Bag of Fishing Treasures
+	[25423] = true, -- Bag of Premium Gems
+	[33844] = true, -- Barrel of Fish
+	[34846] = true, -- Black Sack of Gems
+	[191060] = true, -- Black Sack of Gems
+	[35313] = true, -- Bloated Barbed Gill Trout
+	[35286] = true, -- Bloated Giant Sunfish
+	[28135] = true, -- Bomb Crate
+	[34503] = true, -- Box of Adamantite Shells
+	[191061] = true, -- Brilliant Glass
+	[35945] = true, -- Brilliant Glass
+	[25422] = true, -- Bulging Sack of Gems
+	[23921] = true, -- Bulging Sack of Silver
+	[30320] = true, -- Bundle of Nether Spikes
+	[34548] = true, -- Cache of the Shattered Sun
+	[33857] = true, -- Crate of Meat
+	[34077] = true, -- Crudely Wrapped Gift
+	[27513] = true, -- Curious Crate
+	[30650] = true, -- Dertrok's Wand Case
+	[187714] = true, -- Enlistment Bonus
+	[187799] = true, -- Enlistment Bonus
+	[24336] = true, -- Fireproof Satchel
+	[25424] = true, -- Gem-Stuffed Envelope
+	[37586] = true, -- Handful of Candy
+	[27481] = true, -- Heavy Supply Crate
+	[33928] = true, -- Hollowed Bone Decanter
+	[27511] = true, -- Inscribed Scrollcase
+	[24476] = true, -- Jaggal Clam
+	[31952] = false, -- Khorium Lockbox
+	[32777] = true, -- Kronk's Grab Bag
+	[32626] = true, -- Large Copper Metamorphosis Geode
+	[32629] = true, -- Large Gold Metamorphosis Geode
+	[32624] = true, -- Large Iron Metamorphosis Geode
+	[32628] = true, -- Large Silver Metamorphosis Geode
+	[32462] = true, -- Morthis' Materials
+	[27446] = true, -- Mr. Pinchy's Gift
+	[23895] = true, -- Netted Goods
+	[23846] = true, -- Nolkai's Box
+	[31408] = true, -- Offering of the Sha'tar
+	[32835] = true, -- Ogri'la Care Package
+	[31800] = true, -- Outcast's Cache
+	[24402] = true, -- Package of Identified Plants
+	[35512] = true, -- Pocket Full of Snow
+	[37605] = true, -- Pouch of Pennies
+	[31522] = true, -- Primal Mooncloth Supplies
+	[32064] = true, -- Protectorate Treasure Cache
+	[33045] = true, -- Renn's Supplies
+	[34584] = true, -- Scryer Supplies Package
+	[34585] = true, -- Scryer Supplies Package
+	[34593] = true, -- Scryer Supplies Package
+	[34594] = true, -- Scryer Supplies Package
+	[33926] = true, -- Sealed Scroll Case
+	[35232] = true, -- Shattered Sun Supplies
+	[32724] = true, -- Sludge-covered Object
+	[32627] = true, -- Small Copper Metamorphosis Geode
+	[32630] = true, -- Small Gold Metamorphosis Geode
+	[32625] = true, -- Small Iron Metamorphosis Geode
+	[32631] = true, -- Small Silver Metamorphosis Geode
+	[29569] = false, -- Strong Junkbox
+	[32561] = true, -- Tier 5 Arrow Box
+	[273162] = true, -- Unexpected Gift
+	[25419] = true, -- Unmarked Bag of Gems
+	[30260] = true, -- Voren'thal's Package
+	[34426] = true, -- Winter Veil Gift
+
+	--------------------------------------------------------------------------------
+	-- 03. World of Warcraft : Wrath of the Lich King
+	--------------------------------------------------------------------------------
+
+	[44663] = true, -- Abandoned Adventurer's Satchel
+	[46110] = true, -- Alchemist's Cache
+	[44161] = true, -- Arcane Tarot
+	[39903] = true, -- Argent Crusade Gratuity
+	[39904] = true, -- Argent Crusade Gratuity
+	[49294] = true, -- Ashen Sack of Gems
+	[46007] = true, -- Bag of Fishing Treasures
+	[52274] = true, -- Bag of Shaman Stuff
+	[52344] = true, -- Bag of Shaman Stuff
+	[34119] = true, -- Black Conrad's Treasure
+	[45328] = true, -- Bloated Slippery Eel
+	[40308] = true, -- Bonework Soul Jar
+	[46809] = true, -- Bountiful Cookbook
+	[46810] = true, -- Bountiful Cookbook
+	[208157] = true, -- Bounty Satchel
+	[202269] = true, -- Bounty Satchel
+	[44951] = true, -- Box of Bombs
+	[49909] = true, -- Box of Chocolates
+	[35745] = true, -- Box of Treasure
+	[49926] = true, -- Brazie's Black Book of Secrets
+	[45072] = true, -- Brightly Colored Egg
+	[44700] = true, -- Brooding Darkwater Clam
+	[52676] = true, -- Cache of the Ley-Guardian
+	[45724] = true, -- Champion's Purse
+	[39883] = true, -- Cracked Egg
+	[34871] = true, -- Crafty's Sack
+	[50161] = true, -- Dinner Suit Box
+	[39014] = false, -- Floral Foundations
+	[43622] = false, -- Froststeel Lockbox
+	[262788] = true, -- Grand Gift
+	[54537] = true, -- Heart-Shaped Box
+	[44751] = true, -- Hyldnir Spoils
+	[44943] = true, -- Icy Prism
+	[54535] = true, -- Keg-Shaped Treasure Chest
+	[54218] = true, -- Landro's Gift Box
+	[50301] = true, -- Landro's Pet Box
+	[45878] = true, -- Large Sack of Ulduar Spoils
+	[43346] = true, -- Large Satchel of Spoils
+	[54516] = true, -- Loot-Filled Pumpkin
+	[50160] = true, -- Lovely Dress Box
+	[35792] = true, -- Mage Hunter Personal Effects
+	[41426] = true, -- Magically Wrapped Gift
+	[37168] = true, -- Mysterious Tarot
+	[199210] = true, -- Northrend Adventuring Supplies
+	[200238] = true, -- Northrend Adventuring Supplies
+	[200239] = true, -- Northrend Adventuring Supplies
+	[200240] = true, -- Northrend Adventuring Supplies
+	[46812] = true, -- Northrend Mystery Gem Pouch
+	[39418] = true, -- Ornately Jeweled Box
+	[43556] = true, -- Patroller's Pack
+	[44475] = true, -- Reinforced Crate
+	[43575] = false, -- Reinforced Junkbox
+	[44718] = true, -- Ripe Disgusting Jar
+	[52006] = true, -- Sack of Frosty Treasures
+	[38539] = true, -- Sack of Gold
+	[45875] = true, -- Sack of Ulduar Spoils
+	[54536] = true, -- Satchel of Chilled Goods
+	[51999] = true, -- Satchel of Helpful Goods
+	[52000] = true, -- Satchel of Helpful Goods
+	[52001] = true, -- Satchel of Helpful Goods
+	[52003] = true, -- Satchel of Helpful Goods
+	[52002] = true, -- Satchel of Helpful Goods
+	[52005] = true, -- Satchel of Helpful Goods
+	[52004] = true, -- Satchel of Helpful Goods
+	[43347] = true, -- Satchel of Spoils
+	[44163] = true, -- Shadowy Tarot
+	[44113] = true, -- Small Spice Bag
+	[41888] = true, -- Small Velvet Bag
+	[49631] = true, -- Standard Apothecary Serving Kit
+	[42953] = false, -- Strange Envelope
+	[44142] = true, -- Strange Tarot
+	[54467] = true, -- Tabard Lost & Found
+	[45986] = false, -- Tiny Titanium Lockbox
+	[43624] = false, -- Titanium Lockbox
+	[51316] = true, -- Unsealed Chest
+	[43504] = true, -- Winter Veil Gift
+	[46740] = true, -- Winter Veil Gift
+}

--- a/Features/Announcements.lua
+++ b/Features/Announcements.lua
@@ -48,13 +48,27 @@ function ns:SetQuiet(seconds)
 	end
 end
 
+--[[
+    Announce one item at most once per ns.ITEM_ANNOUNCE_COOLDOWN. Both ignore-list
+    notices share the stamp deliberately: a player who was just told Speedy Loot
+    left an item behind does not also need to be told it will not be opened.
+]]
+function ns:AnnounceItemOnce(formatKey, itemId, link)
+	local now = GetTime()
+	if (now - (ns.state.recentAnnouncements[itemId] or 0)) <= ns.ITEM_ANNOUNCE_COOLDOWN then
+		return
+	end
+	ns.state.recentAnnouncements[itemId] = now
+	ns:PrintMessage(string.format(ns.L[formatKey], link))
+end
+
 function ns:StatusPrint(msg, ...)
 	if IsQuiet() then
 		return
 	end
 	local text = select("#", ...) > 0 and string.format(msg, ...) or msg
 	local now = GetTime()
-	if text == ns.state.lastStatusMsg and (now - ns.state.lastStatusAt) < 5 then
+	if text == ns.state.lastStatusMsg and (now - ns.state.lastStatusAt) < ns.STATUS_REPEAT_COOLDOWN then
 		return
 	end
 	ns.state.lastStatusMsg, ns.state.lastStatusAt = text, now

--- a/Features/Core.lua
+++ b/Features/Core.lua
@@ -14,26 +14,19 @@ local CreateFrame, C_Timer, UnitAffectingCombat, GetTime = CreateFrame, C_Timer,
 local tonumber, wipe, UnitRace, UnitSex = tonumber, wipe, UnitRace, UnitSex
 local UnitCastingInfo, UnitChannelInfo = UnitCastingInfo, UnitChannelInfo
 
+--[[
+    Both target clients expose C_UnitAuras.GetBuffDataByIndex, which returns a
+    named-field table and so sidesteps the old UnitBuff return-position problem
+    (Era put spellId at 10, TBC's extra rank return shifted it to 11).
+]]
+local GetBuffDataByIndex = C_UnitAuras.GetBuffDataByIndex
+
 local function GetPlayerBuffSpellID(index)
-	if C_UnitAuras and C_UnitAuras.GetBuffDataByIndex then
-		local data = C_UnitAuras.GetBuffDataByIndex("player", index)
-		return data and data.spellId
-	end
-	-- Classic ERA: spellId at position 10. TBC: rank at position 2 shifts spellId to position 11.
-	-- Read both; use the one that is a number (the other will be nil or boolean).
-	local _, _, _, _, _, _, _, _, _, pos10, pos11 = _G.UnitBuff("player", index)
-	if type(pos10) == "number" then
-		return pos10
-	end
-	if type(pos11) == "number" then
-		return pos11
-	end
-	return nil
+	local data = GetBuffDataByIndex("player", index)
+	return data and data.spellId
 end
-local GetCVarBool = (C_CVar and C_CVar.GetCVarBool) or function(cvar)
-	return GetCVar(cvar) == "1"
-end
-local SetCVar = (C_CVar and C_CVar.SetCVar) or _G.SetCVar
+
+local GetCVarBool, SetCVar = C_CVar.GetCVarBool, C_CVar.SetCVar
 
 --[[
     Loot-message prefixes, derived once from the global loot format strings
@@ -52,8 +45,7 @@ local lootPushedPrefix = LOOT_ITEM_PUSHED_SELF and LOOT_ITEM_PUSHED_SELF:gsub("%
     @project-version@ token, replaced only at build time, so an unreplaced token
     (the @ is the signal) means a local dev copy and displays as "Dev".
 ]]
-local GetMetadata = (C_AddOns and C_AddOns.GetAddOnMetadata) or GetAddOnMetadata
-local version = GetMetadata and GetMetadata(ADDON_NAME, "Version") or "Dev"
+local version = C_AddOns.GetAddOnMetadata(ADDON_NAME, "Version") or "Dev"
 if version:find("@") then
 	version = "Dev"
 end
@@ -77,6 +69,8 @@ ns.state = {
 	lastFreeSlots = 0,
 	lastLootAt = 0,
 	lastWorldLootAt = 0,
+	-- When Pick Pocket last landed; 0 once its sound has played or nothing came.
+	pickPocketAt = 0,
 	lastStatusAt = 0,
 	lastStatusMsg = nil,
 	openTimerLive = false,
@@ -104,6 +98,20 @@ local function PrintWelcome()
 	ns:PrintMessage(L["CHAT_LOADED"]:format(ns.Version))
 end
 
+--[[
+    Both target clients carry the inventory-full message id as the
+    LE_GAME_ERR_INV_FULL global; neither has Enum.UIERRORS. Since that global is
+    a number, comparing a non-number errorID against it is already false, so no
+    type guard is needed. This is the only inventory-full test in the add-on —
+    the handler and Diagnostics' event-log filter both classify UI_ERROR_MESSAGE
+    through it, so a firing can never pause the add-on while the log files it
+    away as uncorrelated noise. Never add a message-text match beside it: the
+    two would disagree exactly when a bug report needs the log line.
+]]
+function ns.IsBagFullErrorID(errorID)
+	return errorID == LE_GAME_ERR_INV_FULL
+end
+
 local function PlayBagFullSound()
 	local _, raceEnglish = UnitRace("player")
 	local gender = UnitSex("player")
@@ -114,24 +122,83 @@ local function PlayBagFullSound()
 	end
 end
 
-local scanTooltip = CreateFrame("GameTooltip", "OS_ScanTooltip", nil, "GameTooltipTemplate")
+local scanTooltip = CreateFrame("GameTooltip", "OpenSesameScanTooltip", nil, "GameTooltipTemplate")
 scanTooltip:SetOwner(WorldFrame, "ANCHOR_NONE")
 
-local function IsItemLocked(bag, slot)
-	scanTooltip:ClearLines()
-	scanTooltip:SetBagItem(bag, slot)
-	for lineIndex = 1, scanTooltip:NumLines() do
-		local line = _G["OS_ScanTooltipTextLeft" .. lineIndex]
+--[[
+    Does a tooltip carry this exact line? Split out from the two scanners below so
+    the reading and the scanning are separable.
+
+    Matched against the WHOLE line, never as a substring: LOCKED is a short word,
+    and other add-ons write lines that contain it without meaning it.
+]]
+local function TooltipHasLine(tooltip, needle)
+	local tooltipName = tooltip:GetName()
+	if not tooltipName or not needle then
+		return false
+	end
+	for lineIndex = 1, tooltip:NumLines() do
+		local line = _G[tooltipName .. "TextLeft" .. lineIndex]
 		local text = line and line:GetText()
-		if text and text == LOCKED then
+		if text and text == needle then
 			return true
 		end
 	end
 	return false
 end
 
+--[[
+    The same question asked of a bag slot, for callers with no tooltip to read.
+    Exported as ns.IsItemLocked for the queue in this file and the mini-map's
+    Locked Items list. One scan tooltip, one implementation — a second copy would
+    drift.
+
+    THE OWNER IS SET ON EVERY CALL, not once at file scope, and that is
+    load-bearing: hiding a tooltip drops its owner, and an unowned tooltip takes a
+    SetBagItem without complaint and populates NOTHING. Every box then reads as
+    unlocked: no Locked Items list on the mini-map and no tooltip line.
+
+    Setting a tooltip also shows it, hence that Hide: this one is anchored nowhere
+    in particular and has no business being on screen. Shown and hidden inside a
+    single frame, it never renders.
+]]
+local function IsItemLocked(bag, slot)
+	scanTooltip:SetOwner(WorldFrame, "ANCHOR_NONE")
+	scanTooltip:ClearLines()
+	scanTooltip:SetBagItem(bag, slot)
+	local locked = TooltipHasLine(scanTooltip, LOCKED)
+	scanTooltip:Hide()
+	return locked
+end
+ns.IsItemLocked = IsItemLocked
+
+--[[
+    "Does this item begin a quest", which the client will say in a tooltip and
+    nowhere else: no API on either target flags it, and the item's CLASS does not
+    give it away either, since quest starters are ordinary weapons, armour and
+    trinkets as often as they are class 12. Read by hyperlink because the caller
+    has an item, not a bag slot -- this is asked of loot, which may never reach the
+    bags at all.
+
+    The scan is the most expensive question Loot Toasts asks, so it is also the
+    last one asked: everything cheaper has already failed by the time it runs, and
+    it only runs for loot the quality threshold would otherwise have hidden.
+]]
+local function ItemStartsQuest(itemId)
+	if not itemId then
+		return false
+	end
+	scanTooltip:SetOwner(WorldFrame, "ANCHOR_NONE")
+	scanTooltip:ClearLines()
+	scanTooltip:SetHyperlink("item:" .. itemId)
+	local startsQuest = TooltipHasLine(scanTooltip, ITEM_STARTS_QUEST)
+	scanTooltip:Hide()
+	return startsQuest
+end
+ns.ItemStartsQuest = ItemStartsQuest
+
 local function IsPlayerStealthed()
-	if _G.IsStealthed and _G.IsStealthed() then
+	if IsStealthed() then
 		return true
 	end
 	for buffIndex = 1, 40 do
@@ -162,10 +229,25 @@ local function IsSafeToOpen()
 	if not ns.isEnabled or ns.isPaused then
 		return false
 	end
+
+	--[[
+        Where and Group are the player's own hold-off rules: bag slots stay free
+        for drops while in an instance or grouped, and the boxes open once they
+        are back on their own time. GROUP_ROSTER_UPDATE and the non-initial
+        PLAYER_ENTERING_WORLD branch both rescan, so leaving either state resumes
+        opening without waiting on a bag event.
+    ]]
+	if ns.db.profile.autoOpenWhere == "OUTSIDE_INSTANCES" and IsInInstance() then
+		return false
+	end
+	if ns.db.profile.autoOpenGroup == "SOLO_ONLY" and IsInGroup() then
+		return false
+	end
+
 	if UnitAffectingCombat("player") or IsInteractionActive() or IsPlayerStealthed() then
 		return false
 	end
-	if (UnitCastingInfo and UnitCastingInfo("player")) or (UnitChannelInfo and UnitChannelInfo("player")) then
+	if UnitCastingInfo("player") or UnitChannelInfo("player") then
 		return false
 	end
 
@@ -249,7 +331,7 @@ local function BuildQueue()
 		local slots = ns.GetContainerNumSlots(bag)
 		for slot = 1, slots or 0 do
 			local itemId = SafeFastItemID(bag, slot)
-			if itemId then
+			if itemId and not ns:IsIgnored(itemId) then
 				local allowed = ns.AllowedItems[itemId]
 				if allowed == true or (allowed == false and not IsItemLocked(bag, slot)) then
 					QueuePush(bag, slot, itemId)
@@ -259,9 +341,61 @@ local function BuildQueue()
 	end
 end
 
+--[[
+    The locked boxes sitting in the bags waiting on a rogue: allowed but needing
+    an unlock, not on the Ignore List, and still reporting LOCKED. Returned as one
+    row per distinct item with a stack count, sorted by name, for the mini-map
+    tooltip's Locked Items list.
+
+    Computed on demand and deliberately not cached — it runs once per tooltip
+    render, not per frame, and a cache would need invalidating on every bag,
+    trade, and pick-lock event. IsItemLocked is reached only for ids AllowedItems
+    already marks as needing an unlock, so the tooltip scan costs a handful of
+    reads rather than one per bag slot.
+
+    The name is taken from the container's own item link, so it arrives already
+    localized and quality-coloured without a GetItemInfo round trip.
+]]
+function ns.GetLockedBoxes()
+	local rowsById, rows = {}, {}
+	for bag = 0, 4 do
+		local slots = ns.GetContainerNumSlots(bag)
+		for slot = 1, slots or 0 do
+			local itemId = SafeFastItemID(bag, slot)
+			if itemId and ns.AllowedItems[itemId] == false and not ns:IsIgnored(itemId) and IsItemLocked(bag, slot) then
+				local row = rowsById[itemId]
+				if row then
+					row.count = row.count + 1
+				else
+					local link = ns.GetContainerItemLink(bag, slot)
+					row = {
+						itemId = itemId,
+						count = 1,
+						icon = GetItemIcon(itemId),
+						name = link and link:match("|h%[(.-)%]|h"),
+						link = link,
+					}
+					rowsById[itemId] = row
+					rows[#rows + 1] = row
+				end
+			end
+		end
+	end
+	table.sort(rows, function(a, b)
+		if (a.name ~= nil) ~= (b.name ~= nil) then
+			return a.name ~= nil
+		end
+		if a.name and b.name and a.name ~= b.name then
+			return a.name < b.name
+		end
+		return a.itemId < b.itemId
+	end)
+	return rows
+end
+
 local function OpenTick()
 	ns.state.openTimerLive = false
-	if (UnitCastingInfo and UnitCastingInfo("player")) or (UnitChannelInfo and UnitChannelInfo("player")) then
+	if UnitCastingInfo("player") or UnitChannelInfo("player") then
 		ns.state.openTimerLive = true
 		C_Timer.After(ns.OPEN_TICK_INTERVAL, OpenTick)
 		return
@@ -279,7 +413,7 @@ local function OpenTick()
 		ns.UseContainerItem(bag, slot)
 		C_Timer.After(ns.OPEN_RECHECK_DELAY, function()
 			local still = SafeFastItemID(bag, slot)
-			if still == cachedId then
+			if still == cachedId and not ns:IsIgnored(still) then
 				local allowed = ns.AllowedItems[still]
 				if allowed == true or (allowed == false and not IsItemLocked(bag, slot)) then
 					QueuePush(bag, slot, still)
@@ -297,36 +431,48 @@ local function OpenTick()
 	end
 end
 
-local function ScheduleScan(force)
-	local function run()
-		ns.state.scanPending = false
-		ns.state.lastFreeSlots = ns.GetFreeSlots()
-		if ns.isEnabled then
-			local shouldPause = ShouldPause(ns.state.lastFreeSlots)
-			if shouldPause ~= ns.isPaused then
-				ns.isPaused = shouldPause
-				if shouldPause then
-					ns.state.openTimerLive = false
-				end
-				if ns.UpdateMinimapIcon then
-					ns:UpdateMinimapIcon()
-				end
+--[[
+    RunScan and the debounce callback are file-locals rather than closures built
+    inside ScheduleScan: both read only ns.state, so every bag or loot event
+    would otherwise allocate two throwaway functions before deciding whether a
+    scan is even needed.
+]]
+local function RunScan()
+	ns.state.scanPending = false
+	ns.state.lastFreeSlots = ns.GetFreeSlots()
+	if ns.isEnabled then
+		local shouldPause = ShouldPause(ns.state.lastFreeSlots)
+		if shouldPause ~= ns.isPaused then
+			ns.isPaused = shouldPause
+			if shouldPause then
+				ns.state.openTimerLive = false
 			end
-			AnnounceStatus()
+			if ns.UpdateMinimapIcon then
+				ns:UpdateMinimapIcon()
+			end
 		end
-		-- Nothing below runs while disabled: skip the bag walk and tick start.
-		if not ns.isEnabled then
-			return
-		end
-		BuildQueue()
-		if IsSafeToOpen() and not ns.state.openTimerLive and queueHead <= queueTail then
-			ns.state.openTimerLive = true
-			C_Timer.After(ns.OPEN_TICK_INTERVAL, OpenTick)
-		end
+		AnnounceStatus()
 	end
+	-- Nothing below runs while disabled: skip the bag walk and tick start.
+	if not ns.isEnabled then
+		return
+	end
+	BuildQueue()
+	if IsSafeToOpen() and not ns.state.openTimerLive and queueHead <= queueTail then
+		ns.state.openTimerLive = true
+		C_Timer.After(ns.OPEN_TICK_INTERVAL, OpenTick)
+	end
+end
 
+local function OnScanDebounceElapsed()
+	if GetTime() >= ns.state.scanTimerAt then
+		RunScan()
+	end
+end
+
+local function ScheduleScan(force)
 	if force then
-		run()
+		RunScan()
 		return
 	end
 	local wantAt = GetTime() + ns.SCAN_DEBOUNCE
@@ -334,11 +480,7 @@ local function ScheduleScan(force)
 		return
 	end
 	ns.state.scanPending, ns.state.scanTimerAt = true, wantAt
-	C_Timer.After(ns.SCAN_DEBOUNCE, function()
-		if GetTime() >= ns.state.scanTimerAt then
-			run()
-		end
-	end)
+	C_Timer.After(ns.SCAN_DEBOUNCE, OnScanDebounceElapsed)
 end
 ns.ScheduleScan = ScheduleScan
 
@@ -362,7 +504,16 @@ local function ApplyProfile()
 	end
 	ns.ScheduleScan(true)
 	ns:UpdateMinimapIcon()
-	LibStub("AceConfigRegistry-3.0"):NotifyChange(ns.OPTIONS_REGISTRY.General)
+	if ns.ApplyLootToastPosition then
+		ns.ApplyLootToastPosition()
+	end
+	if ns.ApplyLootToastSettings then
+		ns.ApplyLootToastSettings()
+	end
+	local AceConfigRegistry = LibStub("AceConfigRegistry-3.0")
+	for _, registryName in pairs(ns.OPTIONS_REGISTRY) do
+		AceConfigRegistry:NotifyChange(registryName)
+	end
 end
 
 --------------------------------------------------------------------------------
@@ -374,51 +525,16 @@ local EventHandlers = {}
 function EventHandlers:PLAYER_LOGIN()
 	ns.db = LibStub("AceDB-3.0"):New("OpenSesameDB", ns.DATABASE_DEFAULTS, true)
 
-	--[[
-        MIGRATION (remove after 2026-10-06): move flat OpenSesameDB settings into AceDB profile
-        The pre-AceDB model stored each setting as a flat top-level key on
-        OpenSesameDB and the minimap position at OpenSesameDB.minimap. AceDB
-        leaves unknown top-level keys untouched, so lift them into the profile
-        (and the minimap table into global) once, then clear them so the leftover
-        state can't shadow future edits. The flat showMinimap maps to the global
-        minimap `hide` flag rather than a profile key — button visibility is
-        account-wide, not profile-driven.
-    ]]
-	for _, key in ipairs({
-		"autoOpen",
-		"speedyLoot",
-		"lootSounds",
-		"showWelcome",
-		"lockboxNotifications",
-	}) do
-		if OpenSesameDB[key] ~= nil then
-			ns.db.profile[key] = OpenSesameDB[key]
-			OpenSesameDB[key] = nil
-		end
-	end
-	if type(OpenSesameDB.minimap) == "table" then
-		for field, value in pairs(OpenSesameDB.minimap) do
-			if ns.db.global.minimap[field] == nil then
-				ns.db.global.minimap[field] = value
-			end
-		end
-		OpenSesameDB.minimap = nil
-	end
-	if OpenSesameDB.showMinimap ~= nil then
-		ns.db.global.minimap.hide = not OpenSesameDB.showMinimap
-		OpenSesameDB.showMinimap = nil
+	-- Deprecated key: the mini-map subtable moved to the profile under the Simple model.
+	if type(ns.db.global.minimap) == "table" then
+		ns.db.global.minimap = nil
 	end
 
-	--[[
-        MIGRATION (remove after 2026-10-14): move profile.showMinimap into global.minimap.hide
-        Release 2026.07.08.A shipped showMinimap as a profile key. Button
-        visibility is account-wide now, so fold any saved profile value into the
-        global `hide` flag and clear the profile key.
-    ]]
-	if ns.db.profile.showMinimap ~= nil then
-		ns.db.global.minimap.hide = not ns.db.profile.showMinimap
-		ns.db.profile.showMinimap = nil
-	end
+	-- Deprecated keys: the outline and bold toggles became lootToastFontFlags.
+	ns.db.profile.lootToastFontOutline = nil
+	ns.db.profile.lootToastFontBold = nil
+
+	ns:SeedIgnoreList()
 
 	ns.isEnabled = ns.db.profile.autoOpen
 	ns.isSpeedyLoot = ns.db.profile.speedyLoot
@@ -429,8 +545,29 @@ function EventHandlers:PLAYER_LOGIN()
 	ns.db.RegisterCallback(ns, "OnProfileReset", ApplyProfile)
 	ns.db.RegisterCallback(ns, "OnProfileCopied", ApplyProfile)
 
+	if ns.ApplyLootToastPosition then
+		ns.ApplyLootToastPosition()
+	end
+	--[[
+        Toasts ship on, so a profile that has never dismissed the drag handle is
+        shown it here: the feature introducing itself, once, rather than a player
+        meeting it as loot drawn somewhere they did not choose. It stays up until
+        they put it away.
+    ]]
+	if ns.ShowLootToastIntro then
+		ns.ShowLootToastIntro()
+	end
 	if ns.InitMinimap then
 		ns:InitMinimap()
+	end
+	--[[
+        Deliberately hooked HERE rather than while Lockbox-Tooltips.lua loads.
+        Tooltip post-hooks run in the order they were registered, and by
+        PLAYER_LOGIN every add-on has loaded and hooked, so ours runs after
+        theirs and our block reads last. See the note above the hook itself.
+    ]]
+	if ns.InstallTooltipHook then
+		ns.InstallTooltipHook()
 	end
 	ns:UpdateMinimapIcon()
 	PrintWelcome()
@@ -452,6 +589,8 @@ function EventHandlers:PLAYER_ENTERING_WORLD(isInitialLogin, isReloadingUi)
 		end)
 	else
 		ns:SetQuiet(2)
+		-- Zoning out of an instance can lift the Where hold-off, so rescan.
+		ns.ScheduleScan()
 	end
 end
 
@@ -471,11 +610,23 @@ function EventHandlers:UPDATE_STEALTH()
 	end
 end
 
-function EventHandlers:UNIT_SPELLCAST_SUCCEEDED(unit, castGUID, spellID)
-	if unit == "player" and spellID == ns.SPELLS.PICK_LOCK then
+--[[
+    A successful Pick Pocket cast ARMS the sound; it does not play it. The cast
+    succeeding says nothing about whether the pockets held anything -- picking a
+    target whose pockets are already emptied fires this event and a
+    "Your target has already had its pockets picked" error together -- so what the
+    player hears has to wait for loot to actually turn up. See PlayPickPocketSound.
+]]
+function EventHandlers:UNIT_SPELLCAST_SUCCEEDED(unit, _, spellID)
+	if unit ~= "player" then
+		return
+	end
+	if spellID == ns.SPELLS.PICK_LOCK then
 		C_Timer.After(ns.PICK_LOCK_RESCAN_DELAY, function()
 			ns.ScheduleScan(true)
 		end)
+	elseif spellID == ns.SPELLS.PICK_POCKET then
+		ns.state.pickPocketAt = GetTime()
 	end
 end
 
@@ -483,13 +634,11 @@ end
 -- UI_ERROR_MESSAGE
 --------------------------------------------------------------------------------
 
-function EventHandlers:UI_ERROR_MESSAGE(errTypeOrID, msg)
-	local isBagFull = (msg and msg:find(ERR_INV_FULL or "Inventory is full", 1, true))
-	if not isBagFull and type(errTypeOrID) == "number" then
-		isBagFull = (errTypeOrID == (LE_GAME_ERR_INV_FULL or 0))
-			or (Enum and Enum.UIERRORS and errTypeOrID == Enum.UIERRORS.ERR_INV_FULL)
+function EventHandlers:UI_ERROR_MESSAGE(errTypeOrID)
+	if not ns.isEnabled then
+		return
 	end
-	if isBagFull then
+	if ns.IsBagFullErrorID(errTypeOrID) then
 		local now = GetTime()
 		if (now - ns.state.lastBagFullAt) > ns.BAG_FULL_COOLDOWN then
 			ns.state.lastBagFullAt = now
@@ -534,16 +683,13 @@ end
     (Creature-/Vehicle-/GameObject-); "item" when every resolved source is an
     item (Item-) — disenchant, prospect/mill, container open, or the
     white-into-green merge; and "unknown" when there is nothing to go on yet,
-    i.e. GetLootSourceInfo is missing, the window is empty, or the GUIDs have not
-    populated. "unknown" is kept distinct from "item" on purpose: source info can
-    arrive late (and Speedy Loot may loot instantly), so a not-yet-populated
-    corpse must not be mistaken for item loot.
+    i.e. the window is empty or the GUIDs have not populated. "unknown" is kept
+    distinct from "item" on purpose: source info can arrive late (and Speedy Loot
+    may loot instantly), so a not-yet-populated corpse must not be mistaken for
+    item loot.
 ]]
 local function CurrentLootFromWorldSource()
-	if type(GetLootSourceInfo) ~= "function" then
-		return "unknown"
-	end
-	local numItems = (GetNumLootItems and GetNumLootItems()) or 0
+	local numItems = GetNumLootItems()
 	local sawItem = false
 	for slot = 1, numItems do
 		local guid = GetLootSourceInfo(slot)
@@ -583,6 +729,30 @@ local function StampWorldLoot()
 end
 
 --[[
+    The other half of the Pick Pocket sound, and the half that decides whether it
+    is heard at all: a loot window with something in it, opening within
+    PICK_POCKET_LOOT_WINDOW of the cast. A pickpocket that yields nothing opens no
+    window, so nothing here fires and the arming simply times out -- which is the
+    whole point, because the cast alone succeeds either way.
+
+    Disarms as it plays, so the one cast sounds once no matter how many loot
+    events the window generates on the way through.
+
+    MUST BE CALLED BEFORE ns.HandleSpeedyLoot: Speedy Loot empties the slots, and
+    an emptied window is indistinguishable from a pickpocket that came up empty.
+]]
+local function PlayPickPocketSound()
+	if ns.state.pickPocketAt == 0 or not ns.db or not ns.db.profile.pickPocketSound then
+		return
+	end
+	if (GetTime() - ns.state.pickPocketAt) >= ns.PICK_POCKET_LOOT_WINDOW or GetNumLootItems() == 0 then
+		return
+	end
+	ns.state.pickPocketAt = 0
+	PlaySound(ns.PICK_POCKET_SOUND, "Master")
+end
+
+--[[
     One registration owns LOOT_READY. Stamp world-loot state first so the source
     GUIDs are read while the slots are still populated, then run Speedy Loot,
     which empties them via LootSlot. This is the order the two former event
@@ -591,11 +761,13 @@ end
 ]]
 function EventHandlers:LOOT_READY()
 	StampWorldLoot()
+	PlayPickPocketSound()
 	ns.HandleSpeedyLoot()
 end
 
 function EventHandlers:LOOT_OPENED()
 	StampWorldLoot()
+	PlayPickPocketSound()
 end
 
 --[[
@@ -612,6 +784,34 @@ end
 
 EventHandlers.BAG_UPDATE_DELAYED = OnScanRequest
 EventHandlers.BAG_NEW_ITEMS_UPDATED = OnScanRequest
+-- Joining or leaving a group can flip the Group hold-off either way.
+EventHandlers.GROUP_ROSTER_UPDATE = OnScanRequest
+
+--[[
+    The Ignore List panel draws item links, and GetItemInfo returns nil until the
+    client has the item cached. Options-Utilities sets ns.OnItemInfoReceived while
+    any row is still uncached and clears it once nothing is outstanding; routing
+    it through the dispatcher rather than a private frame keeps the single
+    registration rule and puts the event in ns.EVENT_NAMES for the diagnostics
+    probe.
+]]
+function EventHandlers:GET_ITEM_INFO_RECEIVED(itemId)
+	if ns.OnItemInfoReceived then
+		ns.OnItemInfoReceived(itemId)
+	end
+end
+
+--[[
+    Coin is the loot Speedy Loot hides most completely: it has no item, no quality
+    and no link, so nothing else in this file has anything to say about it, and
+    with the loot window gone the only record is the chat line this event carries.
+    The amount comes back out of that sentence -- see ns.ParseMoney.
+]]
+function EventHandlers:CHAT_MSG_MONEY(msg)
+	if ns.ShowMoneyToast then
+		ns.ShowMoneyToast(ns.ParseMoney(msg))
+	end
+end
 
 function EventHandlers:CHAT_MSG_LOOT(msg)
 	if not msg then
@@ -641,10 +841,15 @@ function EventHandlers:CHAT_MSG_LOOT(msg)
 		itemId
 		and ns.AllowedItems
 		and ns.AllowedItems[itemId] == false
+		and not ns:IsIgnored(itemId)
 		and ns.db.profile.autoOpen
-		and ns.db.profile.lockboxNotifications
+		and ns.LockboxNotificationsEnabled()
 	then
 		ns:PrintMessage(string.format(L["ITEM_WILL_AUTO_OPEN"], link))
+	end
+
+	if itemId and ns:IsIgnored(itemId) and ns.db.profile.ignoreListNotifications then
+		ns:AnnounceItemOnce("ITEM_IGNORED", itemId, link)
 	end
 
 	--[[
@@ -654,14 +859,14 @@ function EventHandlers:CHAT_MSG_LOOT(msg)
         even though it travels the same loot + CHAT_MSG_LOOT path.
     ]]
 	if ns.db.profile.lootSounds and (GetTime() - ns.state.lastWorldLootAt) < ns.LOOT_SOUND_WINDOW then
-		local colorSequence = link:match("|c(%x+)|H")
-		if colorSequence and #colorSequence == 8 then
-			local hex = string.lower(string.sub(colorSequence, 3, 8))
-			local q = ns.QUALITY_COLORS[hex]
-			if q and q >= ns.db.profile.lootSoundThreshold then
-				PlaySoundFile(ns.LOOT_SOUND_FILE, "Master")
-			end
+		local quality = ns.GetLinkQuality(link)
+		if quality and quality >= ns.db.profile.lootSoundThreshold then
+			PlaySoundFile(ns.LOOT_SOUND_FILE, "Master")
 		end
+	end
+
+	if ns.ShowLootToast then
+		ns.ShowLootToast(link, msg)
 	end
 
 	OnScanRequest()
@@ -719,31 +924,23 @@ end
 table.sort(ns.EVENT_NAMES)
 
 --[[
-    Register only events valid on the running client. Harmless on current
-    builds (every event in the list is valid on the current target clients);
-    guards future builds where an event name may not exist, so one bad name
-    can't abort the whole loop.
+    Register only events valid on the running client. Every event in the list is
+    valid on both target clients today; the check guards future builds where an
+    event name may not exist, so one bad name can't abort the whole loop.
 ]]
-local IsEventValid = C_EventUtils and C_EventUtils.IsEventValid
+local IsEventValid = C_EventUtils.IsEventValid
 for event in pairs(EventHandlers) do
-	--[[
-        UNIT_SPELLCAST_SUCCEEDED fires for every unit; only the player's own Pick
-        Lock matters here, so filter it to "player" at registration to avoid
-        waking on every group member's cast. The handler keeps its unit ==
-        "player" guard as a belt-and-suspenders check.
-    ]]
-	local isPlayerUnitEvent = event == "UNIT_SPELLCAST_SUCCEEDED"
-	if IsEventValid then
-		if IsEventValid(event) then
-			if isPlayerUnitEvent then
-				eventFrame:RegisterUnitEvent(event, "player")
-			else
-				eventFrame:RegisterEvent(event)
-			end
+	if IsEventValid(event) then
+		--[[
+            UNIT_SPELLCAST_SUCCEEDED fires for every unit; only the player's own
+            Pick Lock matters here, so filter it to "player" at registration to
+            avoid waking on every group member's cast. The handler keeps its
+            unit == "player" guard as a belt-and-suspenders check.
+        ]]
+		if event == "UNIT_SPELLCAST_SUCCEEDED" then
+			eventFrame:RegisterUnitEvent(event, "player")
+		else
+			eventFrame:RegisterEvent(event)
 		end
-	elseif isPlayerUnitEvent then
-		pcall(eventFrame.RegisterUnitEvent, eventFrame, event, "player")
-	else
-		pcall(eventFrame.RegisterEvent, eventFrame, event)
 	end
 end

--- a/Features/Diagnostics.lua
+++ b/Features/Diagnostics.lua
@@ -52,6 +52,10 @@ ns.DiagnosticsStrings = {
 	API_BUTTON = "Test WoW API Endpoints",
 	LOOT_TITLE = "Loot Method",
 	LOOT_BUTTON = "Test Loot Method API",
+	CVARS_TITLE = "Relevant CVars",
+	CVARS_BUTTON = "Read Relevant CVars",
+	DISPLAY_TITLE = "Display Context",
+	DISPLAY_BUTTON = "Read Display Context",
 	ADDONS_TITLE = "Other Add-ons",
 	ADDONS_BUTTON = "List Installed Add-ons",
 	SAVED_TITLE = "Saved Variables",
@@ -105,36 +109,90 @@ local EVENT_LOG_SIZE = 500
 local EVENT_LOG_MAX_ARGS = 8
 
 --[[
-    Per-argument byte cap. 64 was too small for loot lines: a single item link
-    (|cff...|Hitem:...|h[Name]|h|r) plus the "You receive loot:" prefix runs past
-    80 bytes, so the link was getting cut mid-name and the entry collapsed to a
-    sliver like "[Sc". 255 holds a full loot line with its link while still
-    bounding a runaway argument.
+    Per-argument byte cap. It has to clear a full loot line: a single item link
+    (|cff...|Hitem:...|h[Name]|h|r) plus the "You receive loot:" prefix runs well
+    past 80 bytes, and a cap under that slices the link mid-name and collapses the
+    entry to a sliver like "[Sc". 255 holds the line while still bounding a
+    runaway argument.
 ]]
 local EVENT_LOG_MAX_ARG_LENGTH = 255
 
 --[[
-    Events ns:LogEvent drops before recording — deliberately empty. The
-    dispatcher only ever hands LogEvent the events Open Sesame registers (Core's
-    EventHandlers), and none of those is a sustained firehose worth dropping: the
-    addon listens on the coalesced BAG_UPDATE_DELAYED rather than raw BAG_UPDATE,
-    and every registered event is potential signal in a bug report — including
-    UNIT_SPELLCAST_SUCCEEDED, player-filtered at registration, whose rare Pick
-    Lock cast drives the lockbox rescan. The lookup in LogEvent stays so a genuine
-    no-signal firehose can be excluded here if one is ever registered. Generic
-    offenders (COMBAT_LOG_EVENT_UNFILTERED, UNIT_AURA, ...) do not belong here
-    unless registered — the log never sees an event the addon didn't register.
+    Events ns:LogEvent drops entirely before recording — deliberately empty, and
+    the drop-entirely mechanism is currently unused. Nothing Open Sesame
+    registers is pure noise: the addon listens on the coalesced
+    BAG_UPDATE_DELAYED rather than raw BAG_UPDATE, and every registered event is
+    potential signal in a bug report. UI_ERROR_MESSAGE is the one firehose here,
+    but it is only *sometimes* noise — the inventory-full firing is exactly what
+    the log needs — so it goes through the per-id filter below instead of being
+    excluded. Generic offenders (COMBAT_LOG_EVENT_UNFILTERED, UNIT_AURA, ...) do
+    not belong here unless registered: the log never sees an event the addon
+    didn't register.
 ]]
 ns.DIAGNOSTIC_EVENT_EXCLUDE = {}
 
+--[[
+    Events that carry a message id, and the argument position it arrives in.
+    ns:SuppressUncorrelatedMessage classifies these per firing rather than
+    dropping the event wholesale.
+]]
+ns.MESSAGE_ID_FILTERED_EVENTS = {
+	UI_ERROR_MESSAGE = 1,
+}
+
+--[[
+    Per-firing filter for the events above. UI_ERROR_MESSAGE fires on every red
+    combat error ("Ability is not ready yet."), which against a bounded buffer
+    silently evicts the entries the log exists to carry. The allowlist is what
+    the addon actually correlates — the inventory-full id, classified through
+    Core's ns.IsBagFullErrorID so this can never drift from the live handler.
+    Everything else folds into a per-id counter (first-seen text plus a count)
+    rendered as one block at the end of the report. A firing carrying no numeric
+    id in the filtered position is unclassifiable, and unclassifiable is signal:
+    it logs verbatim.
+
+    Returns true when the firing was counted and must not reach the buffer.
+]]
+function ns:SuppressUncorrelatedMessage(event, ...)
+	local idPosition = ns.MESSAGE_ID_FILTERED_EVENTS[event]
+	if not idPosition then
+		return false
+	end
+	local messageID = select(idPosition, ...)
+	if type(messageID) ~= "number" then
+		return false
+	end
+	if ns.IsBagFullErrorID(messageID) then
+		return false
+	end
+	local suppressed = ns.diagnostics.suppressed
+	if not suppressed then
+		return true
+	end
+	local entry = suppressed[messageID]
+	if entry then
+		entry.count = entry.count + 1
+		return true
+	end
+	local text = ""
+	if select("#", ...) > idPosition then
+		local raw = string.sub(tostring((select(idPosition + 1, ...))), 1, EVENT_LOG_MAX_ARG_LENGTH)
+		text = (raw:gsub("|", "||"))
+	end
+	suppressed[messageID] = { event = event, text = text, count = 1 }
+	return true
+end
+
 function ns:StartEventLog()
 	ns.diagnostics.log = {}
+	ns.diagnostics.suppressed = {}
 	ns.diagnostics.logging = true
 end
 
 function ns:StopEventLog()
 	ns.diagnostics.logging = false
 	ns.diagnostics.log = nil
+	ns.diagnostics.suppressed = nil
 end
 
 --[[
@@ -154,6 +212,9 @@ function ns:LogEvent(event, ...)
 	if ns.DIAGNOSTIC_EVENT_EXCLUDE[event] then
 		return
 	end
+	if ns:SuppressUncorrelatedMessage(event, ...) then
+		return
+	end
 	local parts = {}
 	for index = 1, select("#", ...) do
 		if index > EVENT_LOG_MAX_ARGS then
@@ -169,6 +230,36 @@ function ns:LogEvent(event, ...)
 	end
 end
 
+--[[
+    Renders the suppressed-traffic counters as one compact block, biggest
+    offender first. This is also how a tester discovers a message id the addon
+    should be correlating but isn't.
+]]
+local function AppendSuppressedSummary(lines)
+	local suppressed = ns.diagnostics.suppressed
+	if not suppressed then
+		return
+	end
+	local rows = {}
+	for messageID, entry in pairs(suppressed) do
+		rows[#rows + 1] = { id = messageID, entry = entry }
+	end
+	if #rows == 0 then
+		return
+	end
+	table.sort(rows, function(a, b)
+		if a.entry.count ~= b.entry.count then
+			return a.entry.count > b.entry.count
+		end
+		return a.id < b.id
+	end)
+	lines[#lines + 1] = ""
+	lines[#lines + 1] = "Suppressed uncorrelated traffic:"
+	for _, row in ipairs(rows) do
+		lines[#lines + 1] = string.format("%s(%d, %s) x%d", row.entry.event, row.id, row.entry.text, row.entry.count)
+	end
+end
+
 function ns:BuildEventLogReport()
 	local lines = { GetClientHeader(), "" }
 	local log = ns.diagnostics.log
@@ -179,6 +270,7 @@ function ns:BuildEventLogReport()
 			lines[#lines + 1] = entry
 		end
 	end
+	AppendSuppressedSummary(lines)
 	return table.concat(lines, "\n")
 end
 
@@ -206,14 +298,10 @@ end
 
 function ns:RunEventChecks()
 	local lines = { GetClientHeader(), "" }
-	local hasIsEventValid = type(C_EventUtils) == "table" and type(C_EventUtils.IsEventValid) == "function"
 	local probe = GetProbeFrame()
 	local failures = 0
 	for _, event in ipairs(ns.EVENT_NAMES or {}) do
-		local valid = "n/a"
-		if hasIsEventValid then
-			valid = C_EventUtils.IsEventValid(event) and "valid" or "INVALID"
-		end
+		local valid = C_EventUtils.IsEventValid(event) and "valid" or "INVALID"
 		local ok = pcall(probe.RegisterEvent, probe, event)
 		if ok then
 			probe:UnregisterEvent(event)
@@ -237,9 +325,12 @@ end
 
 --[[
     Existence and shape checks only: read-only, no side effects, no protected
-    calls. Kept aligned with the API guards in Features/Utilities.lua,
-    Features/Core.lua, and Features/Speedy-Loot.lua. Modern and legacy fallbacks
-    are listed separately so the report shows exactly what each client provides.
+    calls. One row per API the add-on actually calls - Features/Utilities.lua,
+    Features/Core.lua, Features/Speedy-Loot.lua, Features/Lockbox-Tooltips.lua,
+    Features/Loot-Toasts.lua, Options/Options.lua and this file - plus the
+    handful of client values they read. Every API reached through an
+    availability guard carries a row here, so a FAIL names the guard that is
+    about to take the fallback path rather than leaving it silent.
 ]]
 ns.DIAGNOSTIC_API_CHECKS = {
 	-- { label, testFunction }
@@ -250,9 +341,15 @@ ns.DIAGNOSTIC_API_CHECKS = {
 		end,
 	},
 	{
-		"GetAddOnMetadata (legacy)",
+		"C_AddOns.GetAddOnInfo",
 		function()
-			return type(GetAddOnMetadata) == "function"
+			return type(C_AddOns) == "table" and type(C_AddOns.GetAddOnInfo) == "function"
+		end,
+	},
+	{
+		"C_AddOns.GetNumAddOns",
+		function()
+			return type(C_AddOns) == "table" and type(C_AddOns.GetNumAddOns) == "function"
 		end,
 	},
 	{
@@ -262,21 +359,9 @@ ns.DIAGNOSTIC_API_CHECKS = {
 		end,
 	},
 	{
-		"GetContainerNumSlots (legacy)",
-		function()
-			return type(GetContainerNumSlots) == "function"
-		end,
-	},
-	{
 		"C_Container.GetContainerNumFreeSlots",
 		function()
 			return type(C_Container) == "table" and type(C_Container.GetContainerNumFreeSlots) == "function"
-		end,
-	},
-	{
-		"GetContainerNumFreeSlots (legacy)",
-		function()
-			return type(GetContainerNumFreeSlots) == "function"
 		end,
 	},
 	{
@@ -286,21 +371,9 @@ ns.DIAGNOSTIC_API_CHECKS = {
 		end,
 	},
 	{
-		"GetContainerItemID (legacy)",
-		function()
-			return type(GetContainerItemID) == "function"
-		end,
-	},
-	{
 		"C_Container.GetContainerItemLink",
 		function()
 			return type(C_Container) == "table" and type(C_Container.GetContainerItemLink) == "function"
-		end,
-	},
-	{
-		"GetContainerItemLink (legacy)",
-		function()
-			return type(GetContainerItemLink) == "function"
 		end,
 	},
 	{
@@ -310,9 +383,113 @@ ns.DIAGNOSTIC_API_CHECKS = {
 		end,
 	},
 	{
-		"UseContainerItem (legacy)",
+		"GetSpellInfo",
 		function()
-			return type(UseContainerItem) == "function"
+			return type(GetSpellInfo) == "function"
+		end,
+	},
+	{
+		"GetNumSkillLines",
+		function()
+			return type(GetNumSkillLines) == "function"
+		end,
+	},
+	{
+		"GetSkillLineInfo",
+		function()
+			return type(GetSkillLineInfo) == "function"
+		end,
+	},
+	--[[
+        Not an API so much as a row of client data the add-on depends on: spell
+        1809's name is the localized name of the Lockpicking skill line, and
+        Features/Lockbox-Tooltips.lua has no other handle for finding the player's
+        rank. A FAIL here means the requirement line goes neutral instead of green
+        or red.
+    ]]
+	{
+		"Lockpicking skill name (spell 1809)",
+		function()
+			return type(ns.GetSpellName(ns.SPELLS.LOCKPICKING)) == "string"
+		end,
+	},
+	{
+		"GetItemInfo",
+		function()
+			return type(GetItemInfo) == "function"
+		end,
+	},
+	{
+		"GetItemInfoInstant",
+		function()
+			return type(GetItemInfoInstant) == "function"
+		end,
+	},
+	--[[
+        A position, not an endpoint. Loot Toasts' Bind on Pickup bypass reads
+        bindType as GetItemInfo's 14th return, which is the one thing in that
+        feature no type check would catch if a client shifted it. Probed against
+        the Hearthstone, which is Bind on Pickup and in every player's bag, so the
+        row answers from a warm cache on any character.
+    ]]
+	{
+		"GetItemInfo bindType (14th return)",
+		function()
+			return select(14, GetItemInfo(ns.ITEM_BIND_PROBE_ID)) == ns.ITEM_BIND_ON_PICKUP
+		end,
+	},
+	--[[
+        Client strings the add-on reads rather than translates. ITEM_STARTS_QUEST
+        is matched against a tooltip line to spot a quest starter, ITEM_MIN_SKILL
+        becomes the pattern that decides whether the client already states a
+        lockbox's requirement, the two LOOT_ITEM formats become the prefixes that
+        identify the player's own loot, and the three AMOUNT formats are turned
+        into patterns to read a coin total out of a loot message. For all of these
+        a FAIL means the feature goes quiet rather than errors: an unmatched
+        pattern simply never matches. LOCKED below is the exception and says so.
+    ]]
+	{
+		"ITEM_STARTS_QUEST (global string)",
+		function()
+			return type(ITEM_STARTS_QUEST) == "string"
+		end,
+	},
+	{
+		"ITEM_MIN_SKILL (global string)",
+		function()
+			return type(ITEM_MIN_SKILL) == "string"
+		end,
+	},
+	-- A FAIL silences the loot sound and every loot toast: neither can identify the player's own loot without these.
+	{
+		"LOOT_ITEM_SELF / LOOT_ITEM_PUSHED_SELF (global strings)",
+		function()
+			return type(LOOT_ITEM_SELF) == "string" and type(LOOT_ITEM_PUSHED_SELF) == "string"
+		end,
+	},
+	-- The one row whose FAIL is not silence: with no LOCKED, every box reads as unlocked and the queue tries to open boxes it cannot.
+	{
+		"LOCKED (global string)",
+		function()
+			return type(LOCKED) == "string"
+		end,
+	},
+	{
+		"GOLD_AMOUNT / SILVER_AMOUNT / COPPER_AMOUNT (global strings)",
+		function()
+			return type(GOLD_AMOUNT) == "string" and type(SILVER_AMOUNT) == "string" and type(COPPER_AMOUNT) == "string"
+		end,
+	},
+	{
+		"Coin total read back from a loot message",
+		function()
+			return ns.ParseMoney(string.format(GOLD_AMOUNT, 1) .. " " .. string.format(COPPER_AMOUNT, 7)) == 10007
+		end,
+	},
+	{
+		"GetItemIcon",
+		function()
+			return type(GetItemIcon) == "function"
 		end,
 	},
 	{
@@ -364,9 +541,9 @@ ns.DIAGNOSTIC_API_CHECKS = {
 		end,
 	},
 	{
-		"GetLootMethod (legacy)",
+		"C_CVar.GetCVar",
 		function()
-			return type(GetLootMethod) == "function"
+			return type(C_CVar) == "table" and type(C_CVar.GetCVar) == "function"
 		end,
 	},
 	{
@@ -379,12 +556,6 @@ ns.DIAGNOSTIC_API_CHECKS = {
 		"C_CVar.SetCVar",
 		function()
 			return type(C_CVar) == "table" and type(C_CVar.SetCVar) == "function"
-		end,
-	},
-	{
-		"GetCVar (legacy)",
-		function()
-			return type(GetCVar) == "function"
 		end,
 	},
 	{
@@ -412,12 +583,6 @@ ns.DIAGNOSTIC_API_CHECKS = {
 		end,
 	},
 	{
-		"UnitBuff (legacy)",
-		function()
-			return type(UnitBuff) == "function"
-		end,
-	},
-	{
 		"C_EventUtils.IsEventValid",
 		function()
 			return type(C_EventUtils) == "table" and type(C_EventUtils.IsEventValid) == "function"
@@ -430,15 +595,57 @@ ns.DIAGNOSTIC_API_CHECKS = {
 		end,
 	},
 	{
-		"Enum.UIERRORS.ERR_INV_FULL",
+		"GetPhysicalScreenSize",
 		function()
-			return type(Enum) == "table" and type(Enum.UIERRORS) == "table" and Enum.UIERRORS.ERR_INV_FULL ~= nil
+			return type(GetPhysicalScreenSize) == "function"
+		end,
+	},
+	--[[
+        The one availability guard the add-on keeps, in ns:OpenOptionsPanel. A
+        FAIL means the options panel falls through to AceConfigDialog:Open and
+        opens as a floating window instead of docking into the Settings tree.
+    ]]
+	{
+		"Settings.OpenToCategory",
+		function()
+			return type(Settings) == "table" and type(Settings.OpenToCategory) == "function"
+		end,
+	},
+	{
+		"LOOT_SLOT_ITEM",
+		function()
+			return LOOT_SLOT_ITEM ~= nil
 		end,
 	},
 	{
 		"LE_GAME_ERR_INV_FULL",
 		function()
 			return LE_GAME_ERR_INV_FULL ~= nil
+		end,
+	},
+	--[[
+        Both drive the Notifications panel's quality dropdowns at file scope, and
+        ITEM_QUALITY_COLORS also colours the loot-toast preview rows. The colour
+        table is probed for its `hex` field rather than mere existence: a shape
+        change is what would actually break the panel, and an existence check
+        would pass straight through it.
+    ]]
+	{
+		"ITEM_QUALITY_COLORS",
+		function()
+			return type(ITEM_QUALITY_COLORS) == "table"
+				and type(ITEM_QUALITY_COLORS[4]) == "table"
+				and type(ITEM_QUALITY_COLORS[4].hex) == "string"
+		end,
+	},
+	{
+		"ITEM_QUALITY0_DESC .. ITEM_QUALITY4_DESC (global strings)",
+		function()
+			return type(ITEM_QUALITY0_DESC) == "string"
+				and type(ITEM_QUALITY1_DESC) == "string"
+				and type(ITEM_QUALITY2_DESC) == "string"
+				and type(ITEM_QUALITY3_DESC) == "string"
+				and type(ITEM_QUALITY4_DESC) == "string"
 		end,
 	},
 }
@@ -457,12 +664,17 @@ end
 --------------------------------------------------------------------------------
 
 --[[
-    Live read of the loot-method APIs the master-looter guard in Speedy-Loot.lua
-    depends on. An existence check can't prove C_PartyInfo.GetLootMethod returns
-    the (method, partyMasterID, ...) shape the guard destructures, so this prints
-    the actual return values and how Speedy Loot would interpret them. All calls
-    are read-only.
+    Live read of the loot-method API the master-looter stand-down in
+    Speedy-Loot.lua depends on. The API Endpoints report already proves
+    C_PartyInfo.GetLootMethod exists; what an existence check can't prove is that
+    it returns the (method, masterLooterPartyID, ...) shape the stand-down reads,
+    or that the method comes back as the enum NUMBER the literal 2 in
+    Speedy-Loot.lua is written against. So this prints the raw return values with
+    their types, then the verdict Speedy Loot draws from them. All calls are
+    read-only.
 ]]
+
+local LOOT_METHOD_MASTER = 2
 
 local function PackReturns(...)
 	return select("#", ...), { ... }
@@ -471,54 +683,96 @@ end
 function ns:BuildLootMethodReport()
 	local lines = { GetClientHeader(), "" }
 
-	if type(C_PartyInfo) == "table" and type(C_PartyInfo.GetLootMethod) == "function" then
-		local count, values = PackReturns(C_PartyInfo.GetLootMethod())
-		lines[#lines + 1] = string.format("C_PartyInfo.GetLootMethod() -> %d value(s):", count)
-		for index = 1, count do
-			lines[#lines + 1] = string.format("  [%d] (%s) %s", index, type(values[index]), tostring(values[index]))
-		end
-		--[[
-            Simulate what GetLootMethodCompat returns: enum 2 maps to "master" so
-            the lootMethod == "master" guard in Speedy Loot fires correctly.
-            Comparing values[1] directly to "master" would always report
-            isMasterLooter=false even when the player is the master looter.
-        ]]
-		local methodEnum, masterLooterPartyID = values[1], values[2]
-		local convertedMethod
-		if (Enum and Enum.LootMethod and methodEnum == Enum.LootMethod.MasterLoot) or methodEnum == 2 then
-			convertedMethod = "master"
-		else
-			convertedMethod = methodEnum
-		end
-		lines[#lines + 1] = string.format(
-			"Speedy Loot reads lootMethod=%s, masterLooterPartyID=%s -> isMasterLooter=%s",
-			tostring(convertedMethod),
-			tostring(masterLooterPartyID),
-			tostring(convertedMethod == "master" and masterLooterPartyID == 0)
-		)
-	else
-		lines[#lines + 1] = "C_PartyInfo.GetLootMethod: not available"
+	local count, values = PackReturns(C_PartyInfo.GetLootMethod())
+	lines[#lines + 1] = string.format("C_PartyInfo.GetLootMethod() -> %d value(s):", count)
+	for index = 1, count do
+		lines[#lines + 1] = string.format("  [%d] (%s) %s", index, type(values[index]), tostring(values[index]))
 	end
 
-	lines[#lines + 1] = ""
-	if type(GetLootMethod) == "function" then
-		local count, values = PackReturns(GetLootMethod())
-		lines[#lines + 1] = string.format("GetLootMethod() [legacy] -> %d value(s):", count)
-		for index = 1, count do
-			lines[#lines + 1] = string.format("  [%d] (%s) %s", index, type(values[index]), tostring(values[index]))
-		end
-	else
-		lines[#lines + 1] = "GetLootMethod [legacy]: not available"
-	end
+	local method, masterLooterPartyID = values[1], values[2]
+	lines[#lines + 1] = string.format(
+		"Speedy Loot reads lootMethod=%s, masterLooterPartyID=%s -> isMasterLooter=%s",
+		tostring(method),
+		tostring(masterLooterPartyID),
+		tostring(method == LOOT_METHOD_MASTER and masterLooterPartyID == 0)
+	)
 
 	lines[#lines + 1] = ""
-	if type(GetLootThreshold) == "function" then
+	lines[#lines + 1] = string.format(
+		"GetLootThreshold() = %s (context only: the quality at and above which items go through the master-looter window, which is why the skip above takes everything)",
+		tostring(GetLootThreshold())
+	)
+
+	return table.concat(lines, "\n")
+end
+
+--------------------------------------------------------------------------------
+-- Relevant CVars
+--------------------------------------------------------------------------------
+
+--[[
+    autoLootDefault is the CVar the add-on enforces through ns.EnsureAutoLoot,
+    and a player or another add-on turning it back off is the most common cause
+    of "it stopped opening things": both Auto-Opening and Speedy Loot need it.
+    Read twice, raw and as the boolean the add-on actually tests, because those
+    can disagree. Read-only; the taintLog button is the only CVar write here.
+]]
+function ns:BuildCVarReport()
+	local lines = { GetClientHeader(), "" }
+	lines[#lines + 1] = string.format(
+		"autoLootDefault = %s (GetCVarBool: %s)",
+		tostring(C_CVar.GetCVar("autoLootDefault")),
+		tostring(C_CVar.GetCVarBool("autoLootDefault"))
+	)
+	lines[#lines + 1] = string.format("taintLog = %s", tostring(C_CVar.GetCVar("taintLog")))
+	return table.concat(lines, "\n")
+end
+
+--------------------------------------------------------------------------------
+-- Display Context
+--------------------------------------------------------------------------------
+
+--[[
+    What a "my loot toasts are off the edge of the screen" report needs: the
+    resolution and scale the saved anchor point was chosen against, and the
+    point itself. The anchor frame is read through ns.GetLootToastAnchorFrame,
+    which returns nil rather than creating it, so this report never brings a
+    frame into existence as a side effect.
+]]
+function ns:BuildDisplayReport()
+	local lines = { GetClientHeader(), "" }
+	local screenWidth, screenHeight = GetPhysicalScreenSize()
+	lines[#lines + 1] =
+		string.format("GetPhysicalScreenSize() = %s x %s", tostring(screenWidth), tostring(screenHeight))
+	lines[#lines + 1] = string.format("UIParent:GetScale() = %s", tostring(UIParent:GetScale()))
+	lines[#lines + 1] = string.format("uiScale CVar = %s", tostring(C_CVar.GetCVar("uiScale")))
+
+	lines[#lines + 1] = ""
+	local saved = ns.db and ns.db.global and ns.db.global.lootToastPosition
+	if saved and saved.point then
 		lines[#lines + 1] = string.format(
-			"GetLootThreshold() = %s (master-looter skip applies at this quality and above)",
-			tostring(GetLootThreshold())
+			"Saved toast anchor: point=%s relativePoint=%s x=%s y=%s",
+			tostring(saved.point),
+			tostring(saved.relativePoint),
+			tostring(saved.x),
+			tostring(saved.y)
 		)
 	else
-		lines[#lines + 1] = "GetLootThreshold: not available"
+		lines[#lines + 1] = "Saved toast anchor: unset (the default position is in use)"
+	end
+
+	local anchorFrame = ns.GetLootToastAnchorFrame and ns.GetLootToastAnchorFrame()
+	if anchorFrame then
+		local point, _, relativePoint, x, y = anchorFrame:GetPoint()
+		lines[#lines + 1] = string.format(
+			"Live toast anchor: point=%s relativePoint=%s x=%s y=%s",
+			tostring(point),
+			tostring(relativePoint),
+			tostring(x),
+			tostring(y)
+		)
+	else
+		lines[#lines + 1] = "Live toast anchor: not created this session"
 	end
 
 	return table.concat(lines, "\n")
@@ -530,12 +784,10 @@ end
 
 function ns:BuildAddOnReport()
 	local lines = { GetClientHeader(), "" }
-	local getInfo = (C_AddOns and C_AddOns.GetAddOnInfo) or GetAddOnInfo
-	local getMeta = (C_AddOns and C_AddOns.GetAddOnMetadata) or GetAddOnMetadata
-	local count = (C_AddOns and C_AddOns.GetNumAddOns and C_AddOns.GetNumAddOns()) or GetNumAddOns()
+	local count = C_AddOns.GetNumAddOns()
 	for index = 1, count do
-		local name, _, _, loadable = getInfo(index)
-		local version = getMeta(index, "Version") or "?"
+		local name, _, _, loadable = C_AddOns.GetAddOnInfo(index)
+		local version = C_AddOns.GetAddOnMetadata(index, "Version") or "?"
 		lines[#lines + 1] = string.format("%s v%s [%s]", name, version, loadable and "loadable" or "disabled")
 	end
 	return table.concat(lines, "\n")
@@ -545,11 +797,27 @@ end
 -- Saved Variables
 --------------------------------------------------------------------------------
 
+--[[
+    Big item lists are summarized by length rather than printed row by row: the
+    Ignore List grows with every item the player adds, and a per-row dump would
+    bury the settings a bug report is actually read for. Identified by table
+    identity against the live list rather than by key name, so a rename cannot
+    quietly turn the summary back into hundreds of rows.
+]]
+local function CountEntries(list)
+	local count = 0
+	for _ in pairs(list) do
+		count = count + 1
+	end
+	return count
+end
+
 local function DumpTable(value, indent, depth, lines)
 	if depth > 8 then
 		lines[#lines + 1] = indent .. "<max depth>"
 		return
 	end
+	local ignoreList = ns.db and ns.db.global and ns.db.global.ignoreList
 	local keys = {}
 	for key in pairs(value) do
 		keys[#keys + 1] = key
@@ -560,9 +828,13 @@ local function DumpTable(value, indent, depth, lines)
 	for _, key in ipairs(keys) do
 		local entry = value[key]
 		if type(entry) == "table" then
-			lines[#lines + 1] = indent .. tostring(key) .. " = {"
-			DumpTable(entry, indent .. "    ", depth + 1, lines)
-			lines[#lines + 1] = indent .. "}"
+			if ignoreList and entry == ignoreList then
+				lines[#lines + 1] = indent .. tostring(key) .. " = <" .. CountEntries(entry) .. " items>"
+			else
+				lines[#lines + 1] = indent .. tostring(key) .. " = {"
+				DumpTable(entry, indent .. "    ", depth + 1, lines)
+				lines[#lines + 1] = indent .. "}"
+			end
 		else
 			lines[#lines + 1] = indent .. tostring(key) .. " = " .. tostring(entry)
 		end
@@ -604,9 +876,9 @@ end
 ]]
 
 function ns:GetTaintLogState()
-	return tonumber(GetCVar("taintLog")) or 0
+	return tonumber(C_CVar.GetCVar("taintLog")) or 0
 end
 
 function ns:SetTaintLog(enabled)
-	SetCVar("taintLog", enabled and 2 or 0)
+	C_CVar.SetCVar("taintLog", enabled and 2 or 0)
 end

--- a/Features/Ignore-List.lua
+++ b/Features/Ignore-List.lua
@@ -1,0 +1,124 @@
+local _, ns = ...
+
+--------------------------------------------------------------------------------
+-- Ignore List
+--------------------------------------------------------------------------------
+
+--[[
+    The player's list of containers Open Sesame leaves alone entirely: Speedy
+    Loot leaves them in the loot window with a notice, and Auto-Opening never
+    queues them even when ns.AllowedItems allows the item.
+
+    The list is account-wide (ns.db.global.ignoreList) because which containers a
+    player hoards is a decision about the items, not about the character. It is
+    seeded from ns.DEFAULT_IGNORE_ITEMS when missing or empty, per the style
+    guide's default-list rule. An empty list is indistinguishable from a fresh
+    install, so a player who removes every row keeps it empty for the rest of the
+    session and finds it reseeded at the next login. Removing rows individually
+    is what sticks; the rule protects against reintroducing entries a player
+    removed while others remain.
+
+    The saved list stores `true` per entry and nothing else. The note lives in
+    ns.DEFAULT_IGNORE_ITEMS and is looked up at read time rather than copied in at
+    seed time, so a list saved before the notes existed still shows them, and
+    better copy reaches every player without a migration.
+]]
+
+local L = ns.L
+local AceConfigRegistry = LibStub("AceConfigRegistry-3.0")
+
+--[[
+    A row's reason resolves to one of these six rather than carrying its own
+    sentence: the note is player-facing, so free text per row would be one string
+    per row for every locale to translate, sitting outside Locales/ entirely.
+    Five cover the real spread, and ITEM is the fallback for anything new.
+
+    The item names stay out of them on purpose. The client already draws its own
+    localized tooltip directly above this line, so naming the loot again would
+    mean shipping English item names into every locale.
+]]
+local REASON_TEXT = {
+	RAID = L["OPTIONS_IGNORE_REASON_RAID"],
+	QUEST = L["OPTIONS_IGNORE_REASON_QUEST"],
+	RECIPE = L["OPTIONS_IGNORE_REASON_RECIPE"],
+	GEAR = L["OPTIONS_IGNORE_REASON_GEAR"],
+	HOLIDAY = L["OPTIONS_IGNORE_REASON_HOLIDAY"],
+	ITEM = L["OPTIONS_IGNORE_REASON_ITEM"],
+}
+
+local function NotifyChange()
+	AceConfigRegistry:NotifyChange(ns.OPTIONS_REGISTRY.IgnoreList)
+end
+
+function ns:GetIgnoreList()
+	if not ns.db.global.ignoreList then
+		ns.db.global.ignoreList = {}
+	end
+	return ns.db.global.ignoreList
+end
+
+function ns:IsIgnored(itemId)
+	return itemId ~= nil and ns:GetIgnoreList()[itemId] ~= nil
+end
+
+-- The shipped reason for a default entry; nil for anything the player added.
+function ns:GetIgnoreNote(itemId)
+	local entry = itemId and ns.DEFAULT_IGNORE_ITEMS[itemId]
+	if not entry then
+		return nil
+	end
+	return ns.ICON_IGNORED .. " " .. (REASON_TEXT[entry[2]] or REASON_TEXT.ITEM)
+end
+
+function ns:AddIgnoredItem(itemId)
+	if not itemId then
+		return
+	end
+	ns:GetIgnoreList()[itemId] = true
+	ns.ScheduleScan(true)
+	NotifyChange()
+end
+
+function ns:RemoveIgnoredItem(itemId)
+	if not itemId then
+		return
+	end
+	ns:GetIgnoreList()[itemId] = nil
+	ns.ScheduleScan(true)
+	NotifyChange()
+end
+
+--[[
+    Seeding and Restore Defaults share one rule: only rows this client can
+    actually resolve. An id from a later expansion never answers GetItemInfo
+    here, so it would sit in the panel as a bare number forever and keep the
+    refresh watcher armed waiting for news that never comes.
+]]
+local function SeedFrom(list)
+	for itemId, entry in pairs(ns.DEFAULT_IGNORE_ITEMS) do
+		if entry[1] <= ns.currentExpansion then
+			list[itemId] = true
+		end
+	end
+end
+
+function ns:RestoreDefaultIgnoreList()
+	local list = ns:GetIgnoreList()
+	wipe(list)
+	SeedFrom(list)
+	ns.ScheduleScan(true)
+	NotifyChange()
+end
+
+--[[
+    Called from Core's PLAYER_LOGIN right after AceDB:New. Rebuilds only when the
+    saved list is missing or empty, so shipping new default entries never
+    reintroduces items an existing player removed.
+]]
+function ns:SeedIgnoreList()
+	local list = ns:GetIgnoreList()
+	if next(list) then
+		return
+	end
+	SeedFrom(list)
+end

--- a/Features/Lockbox-Tooltips.lua
+++ b/Features/Lockbox-Tooltips.lua
@@ -1,0 +1,243 @@
+local _, ns = ...
+
+local L = ns.L
+local GetColor = ns.GetColor
+
+--------------------------------------------------------------------------------
+-- Lockbox Tooltips
+--------------------------------------------------------------------------------
+
+--[[
+    Adds the required Lockpicking skill to a locked container's tooltip, and on a
+    rogue colours it by whether their skill is high enough. Answers the question
+    the bag raises on its own: why is this box still sitting there, and what do I
+    need to open it.
+
+    Read-only. Nothing here casts, sends chat, or writes state.
+]]
+
+--------------------------------------------------------------------------------
+-- Player Lockpicking Skill
+--------------------------------------------------------------------------------
+
+--[[
+    Finding the player's lockpicking rank needs the skill line's LOCALIZED name,
+    and Classic Era does not publish a LOCKPICKING global -- the Diagnostic Tools
+    API Endpoints report shows it FAIL there while every namespaced API passes.
+
+    The name comes from the client's own spell database instead. Spell 1809 is the
+    skill spell behind skill line 633, and its name IS the skill line's name in
+    whatever language the client is running, so one lookup answers in every locale.
+    Nothing about the player is involved, so it answers for an untrained rogue and
+    on the first hover of the session.
+
+    THE TRAP: the tooltip is not a source for this name. Matching an
+    ITEM_MIN_SKILL pattern against the tooltip's own "Requires Lockpicking (225)"
+    line is circular, because Era never prints that line on a lockbox: the name is
+    never learned, the rank is always nil, and the requirement line stays neutral
+    white instead of green or red. The name has to come from somewhere the client
+    has already spoken, which is the spell database above.
+]]
+local lockpickingSkillName
+
+local function GetLockpickingSkillName()
+	if not lockpickingSkillName then
+		lockpickingSkillName = ns.GetSpellName(ns.SPELLS.LOCKPICKING)
+	end
+	return lockpickingSkillName
+end
+
+--[[
+    The client may still print its own requirement line on some builds, and
+    repeating it would be noise, so the pattern behind ITEM_MIN_SKILL decides which
+    of the two shapes below to add. Matching the format string rather than looking
+    for the skill's name keeps it precise: other add-ons print lines that name
+    Lockpicking without stating a requirement -- ATT's "World Drop > Lockpicking"
+    breadcrumb is one -- and a name match would read those as the client's line.
+]]
+local function BuildRequirementPattern(format)
+	if not format then
+		return nil
+	end
+	--[[
+        Escape the magic characters first, deliberately leaving % alone so the
+        format's own %s and %d survive to become captures on the next two lines.
+        Matching a literal %s needs the pattern "%%s", not "%%%%s".
+    ]]
+	local pattern = format:gsub("([%^%$%(%)%.%[%]%*%+%-%?])", "%%%1")
+	pattern = pattern:gsub("%%s", "(.+)")
+	pattern = pattern:gsub("%%d", "(%%d+)")
+	return pattern
+end
+
+local requirementPattern = BuildRequirementPattern(ITEM_MIN_SKILL)
+
+local function ClientStatesRequirement(tooltip)
+	local tooltipName = tooltip:GetName()
+	if not tooltipName or not requirementPattern then
+		return false
+	end
+	for index = 1, tooltip:NumLines() do
+		local line = _G[tooltipName .. "TextLeft" .. index]
+		local text = line and line:GetText()
+		if text and text:match(requirementPattern) then
+			return true
+		end
+	end
+	return false
+end
+
+--[[
+    The skill lines are the only place the player's CURRENT rank lives; the spell
+    says nothing about rank. Returns nil when the rank cannot be read -- a
+    non-rogue, an untrained rogue, or a client whose spell database did not answer
+    for the skill spell -- and every caller treats nil as "unknown" and falls back
+    to neutral colouring rather than erroring.
+]]
+local function GetPlayerLockpickingSkill()
+	local wantedName = GetLockpickingSkillName()
+	if not wantedName then
+		return nil
+	end
+	for index = 1, GetNumSkillLines() do
+		local skillName, isHeader, _, skillRank = GetSkillLineInfo(index)
+		if not isHeader and skillName == wantedName then
+			return skillRank
+		end
+	end
+	return nil
+end
+ns.GetPlayerLockpickingSkill = GetPlayerLockpickingSkill
+
+--------------------------------------------------------------------------------
+-- Tooltip Line
+--------------------------------------------------------------------------------
+
+--[[
+    A tooltip can be re-processed without being cleared, so every line this file
+    adds has to be checked for before it is added again. Matched as a substring
+    because our own lines carry a colour escape the raw text does not.
+]]
+local function TooltipHasText(tooltip, needle)
+	local tooltipName = tooltip:GetName()
+	if not tooltipName then
+		return false
+	end
+	for index = 1, tooltip:NumLines() do
+		local line = _G[tooltipName .. "TextLeft" .. index]
+		local text = line and line:GetText()
+		if text and text:find(needle, 1, true) then
+			return true
+		end
+	end
+	return false
+end
+
+--[[
+    The bag and slot are not parameters: everything this needs about the item is
+    either its id or already written into the tooltip being handed over.
+]]
+local function AddLockboxLine(tooltip, itemId)
+	if not ns.LockboxTooltipsEnabled() then
+		return
+	end
+	local requiredSkill = itemId and ns.LOCKBOX_SKILL_LEVELS[itemId]
+	if not requiredSkill then
+		return
+	end
+	--[[
+        The branded header doubles as the "already added" mark: a tooltip can be
+        re-processed without being cleared, and one check on the header covers
+        every line the block adds below it.
+    ]]
+	if TooltipHasText(tooltip, L["ADDON_TITLE"]) then
+		return
+	end
+
+	local clientStatesIt = ClientStatesRequirement(tooltip)
+	local skill = ns.IsPlayerRogue() and GetPlayerLockpickingSkill() or nil
+
+	--[[
+        Two shapes, never both. When the client already states the requirement
+        (Classic Era does), repeating it is noise, so the add-on contributes the
+        one thing the client will not: the player's own rank, coloured by whether
+        it clears the box. When the client says nothing, the requirement itself is
+        the useful line.
+    ]]
+	local label, value, color
+	if clientStatesIt then
+		if not skill then
+			return
+		end
+		label, value = L["TOOLTIP_YOUR_LOCKPICKING_LABEL"], skill
+		color = skill >= requiredSkill and GetColor("ON") or GetColor("OFF")
+	else
+		label, value = L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"], requiredSkill
+		color = GetColor("BODY")
+		if skill then
+			color = skill >= requiredSkill and GetColor("ON") or GetColor("OFF")
+		end
+	end
+
+	--[[
+        Own block, set off from the client's own lines: a blank separator, the
+        add-on's name, then the label and its number as a double line so the
+        number sits in the tooltip's right column.
+    ]]
+	tooltip:AddLine(" ")
+	tooltip:AddLine(GetColor("TITLE") .. L["ADDON_TITLE"] .. "|r")
+	tooltip:AddDoubleLine(color .. label .. "|r", color .. value .. "|r")
+
+	tooltip:Show()
+end
+
+--------------------------------------------------------------------------------
+-- Hook
+--------------------------------------------------------------------------------
+
+--[[
+    THE BLOCK GOES LAST BY BEING LATE IN THE FRAME, NEVER BY BEING LATE TO IT.
+
+    Our own place in a tooltip is decided by two things, and only one of them is
+    worth touching:
+
+      - WHEN in the build we add. A SetBagItem post-hook is already about as late
+        as a synchronous add can be: the client's lines are set, OnTooltipSetItem
+        has fired, and every add-on watching that script -- ATT and TSM among them
+        -- has had its say. That is why the block reads as the last thing on the
+        tooltip today.
+      - WHERE we sit among other SetBagItem post-hooks, which run in the order
+        they were registered. Registering at PLAYER_LOGIN instead of at file scope
+        puts us behind every add-on that hooked while loading, for free.
+
+    A THIRD OPTION IS DELIBERATELY REJECTED. Deferring the add to the next frame
+    with C_Timer.After(0) does put the block under everything -- and it FLICKERS
+    BADLY, because a hovered bag button re-runs SetBagItem every frame. The
+    tooltip is rebuilt without our block, gets it a frame later, loses it again on
+    the next rebuild, and strobes for as long as the cursor rests on the item. Do
+    not reintroduce it, in any form that adds lines outside the build itself.
+
+    So this is best-effort by design: an add-on that hooks later, or rebuilds the
+    tooltip on its own schedule, can still land below us. A row out of place beats
+    a tooltip that strobes.
+]]
+--[[
+    SetBagItem is the hook, unguarded: a widget method present on every client,
+    firing for the bag and bank slots the feature is about.
+
+    TooltipDataProcessor.AddTooltipPostCall would be the obvious modern choice and
+    is the wrong one here. It does not exist on either target client, and it hands
+    over an item id with no bag or slot, so the still-locked check cannot run on
+    that path at all.
+]]
+local function InstallTooltipHook()
+	hooksecurefunc(GameTooltip, "SetBagItem", function(tooltip, bag, slot)
+		AddLockboxLine(tooltip, ns.GetContainerItemID(bag, slot))
+	end)
+end
+
+--[[
+    Called from Core's PLAYER_LOGIN, which fires once every add-on has loaded.
+    Routed through the dispatcher like everything else rather than a private frame.
+]]
+ns.InstallTooltipHook = InstallTooltipHook

--- a/Features/Loot-Toasts.lua
+++ b/Features/Loot-Toasts.lua
@@ -1,0 +1,871 @@
+local _, ns = ...
+
+local LSM = LibStub("LibSharedMedia-3.0")
+
+--------------------------------------------------------------------------------
+-- Loot Toasts
+--------------------------------------------------------------------------------
+
+--[[
+    Speedy Loot hides the loot window, so the only record of what was picked up
+    is the chat log. These are a small on-screen readout of the same thing:
+    icon, coloured link, quantity.
+
+    The stack reads like a chat log. A new entry appears at the anchor and
+    everything already on screen shifts one row away from it - upward by
+    default, downward when lootToastGrowth is "DOWN" - so the oldest row is
+    always the one at the far end, fading out of it. That keeps the reading
+    order stable and means the row the player just triggered is always in the
+    same place on screen.
+
+    On by default, since it is what makes hiding the loot window a net gain rather
+    than a loss of information - and because it ships on, a profile that has never
+    dismissed the drag handle is shown it at login, so the feature introduces
+    itself rather than turning up unannounced as loot drawn somewhere the player
+    did not choose.
+
+    Core's CHAT_MSG_LOOT calls ns.ShowLootToast after its own work, only for the
+    player's own loot, so the prefix match is already done by then, and its
+    CHAT_MSG_MONEY calls ns.ShowMoneyToast for the one kind of loot that has no
+    item behind it at all.
+]]
+
+local TOAST_HANDLE_WIDTH = 400 -- The drag handle only; rows size themselves
+local TOAST_HEIGHT = 24 -- Minimum row height; large fonts raise it, see RowHeight
+local TOAST_SPACING = 8 -- Gap between rows, so entries read as separate lines
+local TOAST_TEXT_PADDING = 6 -- Breathing room above and below the text itself
+
+--[[
+    The handle carries its caption as three blank-line-separated rows - the name
+    and the two gestures - over a button in the bottom corner, so it stands as a
+    panel rather than a strip of text the bottom toast row sits on top of.
+
+    BOTH NUMBERS ARE FIXED, never font-derived: the handle marks where rows start,
+    so a size that drifted with the font would walk the whole stack. The height
+    holds the caption's five rendered lines (three rows and the two blanks between
+    them) from the top, the button in the bottom corner, and the padding at both
+    ends -- plus air between the two, which is what the height is really for. The
+    caption hangs from the top and the button sits on the bottom, so every pixel
+    added here lands in the gap between them; too little and the button crowds the
+    last line of text.
+
+    The caption keeps to its own column at one end, and rows hang off the other
+    end (see ns.db.profile.lootToastAlign), so the two never share horizontal
+    space. The width is set by the longest row rather than by the panel: wide
+    enough that the title never wraps.
+]]
+local TOAST_HANDLE_HEIGHT = 130
+local TOAST_HANDLE_LABEL_WIDTH = 260
+local TOAST_HANDLE_BUTTON_WIDTH = 150
+local TOAST_HANDLE_BUTTON_HEIGHT = 22
+local TOAST_HANDLE_PADDING = 10
+
+--[[
+    Everything in a row is measured from the font size, so the layout holds its
+    proportions instead of only looking right at the default.
+
+    The icon ratio came from the pairing that looked correct - a font size beside
+    an icon half again its height - and holds at any size because it is a ratio.
+    A fixed icon size was the bug: raise the font and the same icon shrinks
+    against it and reads as an afterthought. 1.5 is also about right
+    typographically: a font "size" is the em box and capitals fill roughly 0.7 of
+    it, so the icon sits just above the text's visual line height and stays the
+    thing the eye lands on first.
+]]
+local ICON_TO_FONT_RATIO = 1.5
+local ICON_TEXT_GAP_RATIO = 1 / 3 -- Same origin: a gap a third of the font size
+
+--[[
+    How wide a row is allowed to get: room for roughly 64 characters at any size,
+    since a glyph averages about half the em box. That clears the longest thing
+    Classic can name - a random-suffix weapon like "Decapitating Sword of the
+    Monkey" - with headroom for a quantity suffix.
+
+    It has to scale with the font rather than being a fixed number of pixels:
+    doubling the font halves how many characters fit in a given width, so a width
+    generous at the low end of the size range truncates names at the high end.
+
+    This is a ceiling, not the row's working width. Measure sizes the text box to
+    the string itself and only clamps to this when a name overruns it, at which
+    point wrapping is off (a row is a fixed height, so a second line would spill
+    over its neighbour) and the name truncates instead. The frame draws nothing
+    itself, so the width costs nothing visually.
+]]
+local TEXT_WIDTH_RATIO = 32
+
+--[[
+    How many sample rows the unlock preview stands in when the cap is set to
+    Unlimited - there is no count to mirror then, so it shows the shipped
+    default instead.
+]]
+local SAMPLE_COUNT_UNLIMITED = 8
+
+local anchor
+local pool = {}
+local active = {}
+local samples = {}
+
+--------------------------------------------------------------------------------
+-- Appearance
+--------------------------------------------------------------------------------
+
+--[[
+    Fonts come from LibSharedMedia, the registry ElvUI, Details, WeakAuras and
+    the rest publish into. Open Sesame ships it, so the dropdown is never empty:
+    on its own the library still registers the faces the WoW client itself
+    carries, and on a client running anything else that uses it the player gets
+    that whole shared library here instead.
+
+    LSM also masks its list by locale, so a koKR client is only ever offered
+    faces that can draw Korean.
+]]
+
+--[[
+    DEFAULT is our own sentinel, not a registered face: it resolves to whatever
+    GameFontNormal is currently using, which is the only correct answer on a
+    locale whose client ships its own font. Anything the library no longer knows
+    falls back to that same face rather than to nothing.
+]]
+local function FontPath(value, defaultPath)
+	if not value or value == "DEFAULT" then
+		return defaultPath
+	end
+	return LSM:IsValid("font", value) and LSM:Fetch("font", value) or defaultPath
+end
+
+--[[
+    Rebuilt on every call rather than cached, so a face registered by an add-on
+    that loaded after this one still turns up the next time the dropdown opens.
+]]
+function ns.GetLootToastFontChoices()
+	local values = { DEFAULT = ns.L["OPTIONS_FONT_DEFAULT"] }
+	local sorting = { "DEFAULT" }
+	for _, name in ipairs(LSM:List("font")) do
+		values[name] = name
+		sorting[#sorting + 1] = name
+	end
+	return values, sorting
+end
+
+--[[
+    THE FLAG STRING CARRIES THE WEIGHT, because the client offers no bold. SetFont
+    takes a face, a size and a flag string, and that string is the only control
+    over how heavy the glyphs land: there is no weight axis and no bold cut of
+    Friz Quadrata to swap to. So a thicker outline is what reads as heavier
+    against a bright world background.
+
+    Four of the five stored values are the flag string the client wants verbatim;
+    "NONE" is ours and resolves to the empty string SetFont expects.
+]]
+local function ResolveFlags()
+	local flags = ns.db and ns.db.profile.lootToastFontFlags
+	if not flags or flags == "NONE" then
+		return ""
+	end
+	return flags
+end
+
+--[[
+    Resolved once per restack and passed down, not re-read per row: every row in a
+    pass uses the same face, and FontPath goes through LibSharedMedia's registry.
+
+    Deliberately NOT cached across restacks - a face can be registered by an
+    add-on that loads after this one, and re-resolving each pass is what lets a
+    font change reach rows already on screen.
+]]
+local function ResolveFont()
+	local fallbackPath = GameFontNormal:GetFont()
+	local size = (ns.db and ns.db.profile.lootToastFontSize) or ns.LOOT_TOAST_FONT_SIZE_MIN
+	return FontPath(ns.db and ns.db.profile.lootToastFont, fallbackPath), size, ResolveFlags(), fallbackPath
+end
+
+--[[
+    The flags are the client's own, so the outline is drawn by the font system
+    rather than faked with a shadow. It reads against a bright world background,
+    which is the whole reason a toast needs one. The flags ride both SetFont
+    calls, so a face that fails to load keeps its weight on the fallback.
+]]
+local function ApplyFont(fontString, path, size, flags, fallbackPath)
+	if fontString:SetFont(path, size, flags) == false then
+		fontString:SetFont(fallbackPath, size, flags)
+	end
+end
+
+local function FontSize()
+	return (ns.db and ns.db.profile.lootToastFontSize) or ns.LOOT_TOAST_FONT_SIZE_MIN
+end
+
+local function IconSize()
+	return math.floor(FontSize() * ICON_TO_FONT_RATIO + 0.5)
+end
+
+local function IconGap()
+	return math.max(2, math.floor(FontSize() * ICON_TEXT_GAP_RATIO))
+end
+
+--[[
+    The Unlimited choice is stored as 0, which must never reach the cap
+    arithmetic as a number: `#active >= 0` is always true, so it would retire
+    every row the instant it was drawn. It resolves to infinity instead, which
+    makes the same comparison simply never fire.
+]]
+local function MaxVisible()
+	local limit = ns.db and ns.db.profile.lootToastMaxVisible
+	if not limit or limit <= ns.LOOT_TOAST_UNLIMITED then
+		return math.huge
+	end
+	return limit
+end
+
+local function RowWidth()
+	return IconSize() + IconGap() + math.floor(FontSize() * TEXT_WIDTH_RATIO)
+end
+
+--[[
+    Which end of the anchor a row hangs off, and which side of the row its icon
+    takes. The handle's caption always goes to the opposite end, so the preview
+    text and the rows can never collide.
+]]
+local function AlignsRight()
+	return ns.db ~= nil and ns.db.profile.lootToastAlign == "RIGHT"
+end
+
+--[[
+    The row clears the icon, which the ratio above keeps taller than the text. At
+    the default size this lands exactly on TOAST_HEIGHT, so the usual case looks
+    unchanged; a larger font grows the row rather than spilling over the one above.
+]]
+local function RowHeight()
+	return math.max(TOAST_HEIGHT, IconSize() + TOAST_TEXT_PADDING)
+end
+
+--[[
+    One owner for every font-dependent measurement AND for the row's internal
+    layout, run from Restack, so a change to the font, size, or alignment reaches
+    toasts already on screen instead of only the next one drawn.
+
+    Left-aligned, the icon leads and the name runs right from it; right-aligned,
+    the icon trails and the name runs back toward it, justified so the text ends
+    against the icon rather than trailing off into empty frame.
+]]
+local function Measure(toast, path, size, flags, fallbackPath)
+	local icon = IconSize()
+	local gap = IconGap()
+	toast:SetSize(RowWidth(), RowHeight())
+	toast.icon:SetSize(icon, icon)
+	toast.icon:ClearAllPoints()
+	toast.text:ClearAllPoints()
+
+	-- Font first: SetFont resets a font string's justification, so justifying
+	-- before it silently loses the setting on whichever rows it touches.
+	ApplyFont(toast.text, path, size, flags, fallbackPath)
+
+	--[[
+        THE TRAP: a text box spanning the whole row makes the name's position
+        depend on justifyH, so one row holding a stale justification stranded its
+        name at the far end of the row - hundreds of pixels from its own icon.
+
+        The box is sized to the string instead (SetWidth(0) auto-sizes) and
+        pinned directly to the icon, so the glyphs sit against the icon by
+        geometry rather than by justification. Only a name too long for the row
+        takes a fixed width, and it fills that box, so justification cannot move
+        it far either way.
+    ]]
+	toast.text:SetWidth(0)
+	if AlignsRight() then
+		toast.icon:SetPoint("RIGHT")
+		toast.text:SetPoint("RIGHT", toast.icon, "LEFT", -gap, 0)
+		toast.text:SetJustifyH("RIGHT")
+	else
+		toast.icon:SetPoint("LEFT")
+		toast.text:SetPoint("LEFT", toast.icon, "RIGHT", gap, 0)
+		toast.text:SetJustifyH("LEFT")
+	end
+
+	local maxTextWidth = RowWidth() - icon - gap
+	if toast.text:GetStringWidth() > maxTextWidth then
+		toast.text:SetWidth(maxTextWidth)
+	end
+end
+
+--------------------------------------------------------------------------------
+-- Anchor
+--------------------------------------------------------------------------------
+
+--[[
+    The anchor is the fixed point toasts stack from. Its saved point lives in
+    ns.db.global.lootToastPosition — presentation state, account-wide alongside
+    the Ignore List, because where a player wants this on their screen is not a
+    per-character decision.
+]]
+local function GetAnchor()
+	if anchor then
+		return anchor
+	end
+	anchor = CreateFrame("Button", "OpenSesameLootToastAnchor", UIParent)
+	-- Fixed: the handle marks where rows start, so its own size must not drift
+	-- with the font, or changing the font size would walk the whole stack sideways.
+	anchor:SetSize(TOAST_HANDLE_WIDTH, TOAST_HANDLE_HEIGHT)
+	anchor:SetMovable(true)
+	anchor:SetClampedToScreen(true)
+	anchor:Hide()
+
+	anchor.background = anchor:CreateTexture(nil, "BACKGROUND")
+	anchor.background:SetAllPoints()
+	anchor.background:SetColorTexture(0, 0, 0, 0.5)
+
+	--[[
+        A width of its own, so the caption keeps to its column and a long
+        translated title wraps inside the handle instead of running under the
+        rows at the far end. Anchored from the TOP rather than centred, because a
+        button hangs off its bottom edge and the two have to stack predictably.
+    ]]
+	anchor.label = anchor:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+	anchor.label:SetWidth(TOAST_HANDLE_LABEL_WIDTH)
+	anchor.label:SetJustifyV("TOP")
+
+	--[[
+        The way out, offered where the feature is: a player meeting toasts for the
+        first time should not have to find an options panel to decline them. The
+        options checkbox says the same thing and stays the place to turn them back
+        on, which is what the line above this button is for.
+    ]]
+	anchor.disable = CreateFrame("Button", nil, anchor, "UIPanelButtonTemplate")
+	anchor.disable:SetSize(TOAST_HANDLE_BUTTON_WIDTH, TOAST_HANDLE_BUTTON_HEIGHT)
+	anchor.disable:SetText(ns.L["OPTIONS_TOASTS_DISABLE_BUTTON"])
+	anchor.disable:SetScript("OnClick", function()
+		ns.DismissLootToastIntro()
+		ns.SetLootToastsEnabled(false)
+	end)
+
+	anchor:SetScript("OnDragStart", function(self)
+		self:StartMoving()
+	end)
+	anchor:SetScript("OnDragStop", function(self)
+		self:StopMovingOrSizing()
+		ns.SaveLootToastPosition()
+	end)
+
+	--[[
+        Locking from the handle itself, so a player who dragged it somewhere odd
+        does not have to find the options panel again to put it away. Left drag
+        moves, right click locks, and the handle says so.
+    ]]
+	anchor:RegisterForClicks("RightButtonUp")
+	anchor:SetScript("OnClick", function()
+		ns.DismissLootToastIntro()
+		ns.SetLootToastsUnlocked(false)
+	end)
+	return anchor
+end
+
+-- The read-only half of GetAnchor, for callers that must not create the frame.
+-- Returns nil until something has actually raised the handle.
+function ns.GetLootToastAnchorFrame()
+	return anchor
+end
+
+--[[
+    Pin the handle's caption to the end the rows do NOT use and justify it into
+    that end, then put the button in the corner below it, on the same end and at
+    the same inset - so its edge lines up with the text's rather than floating.
+    Both are anchored to the panel rather than to each other: the caption hangs
+    from the top, the button sits on the bottom, and the air between them is
+    whatever the height leaves over.
+
+    Re-run on every appearance change, since the alignment setting can flip which
+    end all of this belongs to.
+]]
+local function ApplyHandleLayout()
+	local frame = GetAnchor()
+	frame.label:ClearAllPoints()
+	frame.disable:ClearAllPoints()
+	if AlignsRight() then
+		frame.label:SetPoint("TOPLEFT", frame, "TOPLEFT", TOAST_HANDLE_PADDING, -TOAST_HANDLE_PADDING)
+		frame.label:SetJustifyH("LEFT")
+		frame.disable:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", TOAST_HANDLE_PADDING, TOAST_HANDLE_PADDING)
+	else
+		frame.label:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -TOAST_HANDLE_PADDING, -TOAST_HANDLE_PADDING)
+		frame.label:SetJustifyH("RIGHT")
+		frame.disable:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -TOAST_HANDLE_PADDING, TOAST_HANDLE_PADDING)
+	end
+end
+
+function ns.ApplyLootToastPosition()
+	local frame = GetAnchor()
+	local saved = ns.db and ns.db.global.lootToastPosition
+	frame:ClearAllPoints()
+	if saved and saved.point then
+		frame:SetPoint(saved.point, UIParent, saved.relativePoint, saved.x, saved.y)
+	else
+		-- Default: above centre, clear of the action bars and the chat frame.
+		frame:SetPoint("CENTER", UIParent, "CENTER", 0, 200)
+	end
+end
+
+function ns.SaveLootToastPosition()
+	local frame = GetAnchor()
+	local point, _, relativePoint, x, y = frame:GetPoint()
+	ns.db.global.lootToastPosition = { point = point, relativePoint = relativePoint, x = x, y = y }
+end
+
+function ns.ResetLootToastPosition()
+	ns.db.global.lootToastPosition = {}
+	ns.ApplyLootToastPosition()
+end
+
+--[[
+    Unlocking shows the anchor as a draggable handle so the player can see what
+    they are moving; locking hides it again. Purely visual, no secure frames.
+]]
+function ns.SetLootToastsUnlocked(unlocked)
+	local frame = GetAnchor()
+	if unlocked then
+		--[[
+            The name, then the two gestures the handle answers to, in the order a
+            player meets them: drag it where they want it, then put it away. The
+            way out of the feature entirely is the button below, not a third line
+            of text - saying it twice was one line too many.
+
+            Blank lines between: three sentences stacked tight read as a
+            paragraph, spaced out they read as a list of things to try.
+
+            Body white rather than helper silver. Silver is for text beside
+            something brighter that carries the point; here these lines ARE the
+            point, and they are read over open world at whatever the ground
+            happens to be.
+        ]]
+		local body = ns.GetColor("BODY")
+		local function BodyLine(key)
+			return "\n\n" .. body .. ns.L[key] .. "|r"
+		end
+		frame.label:SetText(
+			ns.GetColor("TITLE")
+				.. ns.L["ADDON_TITLE"]
+				.. " "
+				.. ns.L["LOOT_TOASTS"]
+				.. "|r"
+				.. BodyLine("OPTIONS_TOASTS_CLICK_DRAG")
+				.. BodyLine("OPTIONS_TOASTS_RIGHT_CLICK_LOCK")
+		)
+		frame:RegisterForDrag("LeftButton")
+		frame:EnableMouse(true)
+		frame:Show()
+	else
+		frame:RegisterForDrag()
+		frame:EnableMouse(false)
+		frame:Hide()
+	end
+	ns.lootToastsUnlocked = unlocked and true or false
+	ns.RefreshLootToastSamples()
+end
+
+function ns.AreLootToastsUnlocked()
+	return ns.lootToastsUnlocked == true
+end
+
+--------------------------------------------------------------------------------
+-- The Introduction
+--------------------------------------------------------------------------------
+
+--[[
+    TOASTS SHIP ON, so the first a player would otherwise know about them is loot
+    they did not ask to see drawn somewhere they did not choose. So a profile that
+    has never dismissed the handle gets it raised at login: it says what the
+    feature is, where it will draw, how to move it, how to put it away, and offers
+    a button to decline the whole thing. It is the feature introducing itself.
+
+    Dismissing is the player's, and it is remembered per profile - which is what
+    makes a new or reset profile show it again, deliberately, since that profile
+    has not been told either. Any of the three ways out counts as being told: the
+    right-click the handle advertises, the Disable button on it, and the panel's
+    own Lock button.
+]]
+function ns.DismissLootToastIntro()
+	if ns.db then
+		ns.db.profile.lootToastsIntroSeen = true
+	end
+end
+
+function ns.ShowLootToastIntro()
+	if not ns.db or ns.db.profile.lootToastsIntroSeen or not ns.db.profile.lootToasts then
+		return
+	end
+	ns.SetLootToastsUnlocked(true)
+end
+
+--[[
+    Re-apply the active profile's toast settings, called from Core's ApplyProfile
+    on a profile switch, reset, or copy.
+
+    A switch settles the handle to locked first in every case: hidden outright
+    when the incoming profile has the feature off, and hidden rather than left up
+    when it has it on, because unlocking is a runtime choice the profile does not
+    carry. ns.SetLootToastsUnlocked(false) does both, and the
+    RefreshLootToastSamples it calls re-runs Measure over every row still on
+    screen, so the incoming profile's alignment, growth, font, and size reach
+    toasts already drawn instead of waiting for a reload.
+
+    THEN the incoming profile gets its own introduction, if it is owed one. A
+    fresh profile - new, or reset back to defaults - has never dismissed the
+    handle, so it meets the feature the same way a new player does.
+]]
+function ns.ApplyLootToastSettings()
+	ns.SetLootToastsUnlocked(false)
+	ns.ShowLootToastIntro()
+end
+
+--[[
+    Toggling the feature owns the handle in both directions, and lives here
+    rather than in the options table because it is what the feature does, not
+    what the panel looks like.
+
+    Switching it on raises the handle and its samples. The player has just turned
+    on something that draws on their screen and has no other way to find out
+    where it will draw or how big it will be - the alternative is looting
+    something and hoping. Switching it off puts the handle away, or it would be
+    left on screen with nothing behind it.
+
+    The panel is told either way, because this is now reachable from OUTSIDE the
+    panel - the handle's own Disable button - and a checkbox left ticked for a
+    feature the player just turned off is worse than no checkbox at all.
+]]
+function ns.SetLootToastsEnabled(enabled)
+	ns.db.profile.lootToasts = enabled and true or false
+	ns.SetLootToastsUnlocked(ns.db.profile.lootToasts)
+	LibStub("AceConfigRegistry-3.0"):NotifyChange(ns.OPTIONS_REGISTRY.Notifications)
+end
+
+--------------------------------------------------------------------------------
+-- Toast Frames
+--------------------------------------------------------------------------------
+
+local function AcquireToast()
+	local toast = table.remove(pool)
+	if toast then
+		toast.pooled = nil
+		return toast
+	end
+	toast = CreateFrame("Frame", nil, UIParent)
+
+	-- Both are positioned by Measure, which owns the row's layout per alignment.
+	toast.icon = toast:CreateTexture(nil, "ARTWORK")
+
+	toast.text = toast:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+	-- One line, always. An over-long name ellipsizes rather than breaking the row.
+	toast.text:SetWordWrap(false)
+
+	toast.fade = toast:CreateAnimationGroup()
+	toast.fadeOut = toast.fade:CreateAnimation("Alpha")
+	toast.fadeOut:SetFromAlpha(1)
+	toast.fadeOut:SetToAlpha(0)
+	toast.fadeOut:SetDuration(ns.LOOT_TOAST_FADE_DURATION)
+	toast.fade:SetScript("OnFinished", function(group)
+		ns.ReleaseLootToast(group:GetParent())
+	end)
+	return toast
+end
+
+--[[
+    The dwell is a setting, so it is stamped on the animation at play time rather
+    than when the frame was built - a pooled toast outlives any one choice.
+]]
+local function PlayFade(toast)
+	toast.fadeOut:SetStartDelay(ns.db.profile.lootToastDuration)
+	toast.fade:Play()
+end
+
+--[[
+    `active` runs oldest-first, and the offset is measured from the END of the
+    list, so the newest entry sits at the anchor and age carries a row away from
+    it. The growth setting picks the direction: "UP" hangs rows off the anchor's
+    bottom edge and ages them upward, "DOWN" mirrors the geometry off the top
+    edge and ages them downward. Either way the newest row lands exactly on the
+    handle the player placed.
+
+    The arithmetic is what makes the two movements right. Adding an entry raises
+    `count`, so every row already on screen gains exactly one step - the stack
+    grows away from the anchor. Retiring the oldest drops `count` and every
+    survivor's index by one together, which cancels: nothing near the anchor
+    twitches to fill the gap the departing row left at the far end.
+
+    Rows hang off the anchor's LEFT edge, not its centre. Centred, a row's width
+    would decide where its icon landed, so widening a row to fit longer names
+    would drag the text sideways and a font change would walk the stack across
+    the screen. Anchored left, width only sets where the text runs out.
+]]
+local function Restack()
+	local count = #active
+	local step = RowHeight() + TOAST_SPACING
+	local growDown = ns.db and ns.db.profile.lootToastGrowth == "DOWN"
+	--[[
+        The two settings pick one corner of the anchor between them, and a row is
+        pinned corner-to-corner with it: growth picks TOP or BOTTOM, alignment
+        picks LEFT or RIGHT. Ageing then carries rows away from that corner along
+        the growth axis only.
+    ]]
+	local corner = (growDown and "TOP" or "BOTTOM") .. (AlignsRight() and "RIGHT" or "LEFT")
+	local path, size, flags, fallbackPath = ResolveFont()
+	for index, toast in ipairs(active) do
+		Measure(toast, path, size, flags, fallbackPath)
+		toast:ClearAllPoints()
+		local offset = (count - index) * step
+		toast:SetPoint(corner, GetAnchor(), corner, 0, growDown and -offset or offset)
+	end
+end
+
+--[[
+    THE TRAP: callers loop until a list shrinks - ReleaseSamples on `samples`,
+    ns.ApplyLootToastLimit and ns.ShowLootToast on `active` - so a release that
+    removed nothing would spin forever and freeze the client. The list removals
+    below therefore ALWAYS run, guarded by nothing, and every call makes progress.
+
+    Only the pooling is idempotent: stopping the fade can fire its own OnFinished,
+    which releases the same frame again, and pushing it into the pool twice would
+    hand one frame out as two rows so a row silently goes missing.
+]]
+function ns.ReleaseLootToast(toast)
+	for index, candidate in ipairs(samples) do
+		if candidate == toast then
+			table.remove(samples, index)
+			break
+		end
+	end
+	for index, candidate in ipairs(active) do
+		if candidate == toast then
+			table.remove(active, index)
+			break
+		end
+	end
+	if not toast.pooled then
+		toast.pooled = true
+		toast.fade:Stop()
+		toast:Hide()
+		toast:SetAlpha(1)
+		pool[#pool + 1] = toast
+	end
+	Restack()
+end
+
+--------------------------------------------------------------------------------
+-- Entry Point
+--------------------------------------------------------------------------------
+
+--[[
+    Quantity arrives as an "x2" suffix on the loot message rather than in the
+    link, so it is parsed off the message. A single item carries no suffix and
+    renders as the plain name.
+]]
+local function ParseQuantity(message)
+	if not message then
+		return 1
+	end
+	return tonumber(message:match("x(%d+)%s*%.?%s*$")) or 1
+end
+
+--[[
+    Seven kinds of item are worth seeing whatever the quality threshold says, each
+    behind its own toggle, because for all seven the item's colour is a poor guide
+    to whether the player cares: a quest item, the one pickup they may be actively
+    watching for, is usually Common; so is a recipe worth more than the greens
+    around it; a mount or a pet is a moment regardless of tier; and a bag is the
+    pickup that decides whether the rest of the run fits. Bind on Pickup is the
+    broad one, and it earns its keep on the items no list names.
+
+    A container Open Sesame can open earns its place differently - the toast is the
+    player's cue that the ADD-ON is about to act - which is why that one tests for
+    presence in ns.AllowedItems rather than for the true value, so a still-locked
+    box counts as much as an openable one.
+
+    ORDER HERE IS BY COST, and deliberately not the order the options panel lists
+    them in. The table lookup is free, the GetItemInfoInstant reads answer from the
+    client's own database, and Bind on Pickup goes last because it is the only one
+    needing the full GetItemInfo. That call can answer nil on a cold cache, which
+    reads here as "not Bind on Pickup" and leaves the threshold to decide -
+    acceptable, because the item was just looted, which is the one moment the
+    client is certain to have it cached.
+]]
+local function AlwaysShown(itemId)
+	if not itemId then
+		return false
+	end
+	local profile = ns.db.profile
+	if profile.lootToastContainers and ns.AllowedItems[itemId] ~= nil then
+		return true
+	end
+
+	local _, _, _, _, _, classId, subclassId = GetItemInfoInstant(itemId)
+	if profile.lootToastQuestItems and classId == ns.ITEM_CLASS_QUEST then
+		return true
+	end
+	if profile.lootToastRecipes and classId == ns.ITEM_CLASS_RECIPE then
+		return true
+	end
+	if profile.lootToastKeys and classId == ns.ITEM_CLASS_KEY then
+		return true
+	end
+	if profile.lootToastBags and (classId == ns.ITEM_CLASS_BAG or classId == ns.ITEM_CLASS_QUIVER) then
+		return true
+	end
+	if classId == ns.ITEM_CLASS_MISCELLANEOUS then
+		if profile.lootToastMounts and subclassId == ns.ITEM_SUBCLASS_MOUNT then
+			return true
+		end
+		if profile.lootToastPets and subclassId == ns.ITEM_SUBCLASS_COMPANION_PET then
+			return true
+		end
+	end
+
+	if profile.lootToastBindOnPickup and select(14, GetItemInfo(itemId)) == ns.ITEM_BIND_ON_PICKUP then
+		return true
+	end
+
+	--[[
+        Last, because it is the only question that costs a tooltip. A quest STARTER
+        rides with quest items rather than under a toggle of its own: it is the
+        same "do not walk away from this" case, and the class test above misses it
+        entirely, since a starter is as often an ordinary trinket or blade as it is
+        class 12.
+    ]]
+	return profile.lootToastQuestItems and ns.ItemStartsQuest(itemId)
+end
+
+--[[
+    Everything a row does once its icon and text are decided, shared so an item and
+    a coin pile reach the screen the same way.
+
+    The cap is enforced by retiring the OLDEST toast rather than dropping the new
+    one: a burst of loot should show what just arrived, not freeze on the first
+    five entries.
+]]
+local function PushToast(icon, text)
+	while #active >= MaxVisible() do
+		ns.ReleaseLootToast(active[1])
+	end
+	local toast = AcquireToast()
+	toast.icon:SetTexture(icon)
+	toast.text:SetText(text)
+	toast:SetAlpha(1)
+	toast:Show()
+	active[#active + 1] = toast
+	Restack()
+	PlayFade(toast)
+end
+
+function ns.ShowLootToast(link, message)
+	if not link or not ns.db or not ns.db.profile.lootToasts then
+		return
+	end
+
+	local itemId = tonumber(link:match("item:(%d+)"))
+
+	--[[
+        Below the player's chosen quality, stay quiet, unless the item is one of
+        the always-shown kinds above. An unmapped colour reads as nil and is shown
+        anyway: a toast is a display, and silently swallowing something the player
+        did loot is the worse failure.
+    ]]
+	local quality = ns.GetLinkQuality(link)
+	if quality and quality < ns.db.profile.lootToastThreshold and not AlwaysShown(itemId) then
+		return
+	end
+
+	--[[
+        The square brackets a link carries are chat punctuation - they mark where
+        a link starts and ends in a wall of running text. A toast is one item on
+        its own line, so they only add noise. The quality colour still says it is
+        an item, and the escape sequence is left intact so the text stays a real
+        link rather than a lookalike.
+    ]]
+	local quantity = ParseQuantity(message)
+	local name = (link:gsub("|h%[(.-)%]|h", "|h%1|h"))
+	PushToast(itemId and GetItemIcon(itemId) or nil, quantity > 1 and (name .. " x" .. quantity) or name)
+end
+
+--[[
+    COIN IS THE ONLY LOOT WITH NO ITEM BEHIND IT: no link, no icon of its own, no
+    quality, and so nothing the threshold or the always-shown kinds could ever have
+    an opinion about. It gets a toast on its own terms, or with the loot window
+    hidden it leaves no trace outside the chat log at all.
+
+    Its own toggle for the same reason it needs a toast: every kill drops coin, so
+    this is the row a player will see most often, and the one they are most likely
+    to want gone.
+]]
+function ns.ShowMoneyToast(copper)
+	if not copper or copper <= 0 or not ns.db or not ns.db.profile.lootToasts then
+		return
+	end
+	if not ns.db.profile.lootToastMoney then
+		return
+	end
+	--[[
+        FormatMoney colours itself - white numbers, each suffix in its own coin's
+        colour - so nothing is wrapped around it here. A colour applied over the
+        top would flatten exactly the distinction the format exists to make.
+    ]]
+	PushToast(ns.MoneyIcon(copper), ns.FormatMoney(copper))
+end
+
+--------------------------------------------------------------------------------
+-- Samples
+--------------------------------------------------------------------------------
+
+--[[
+    While the handle is up, stand in one "Example Item" sample per row the cap
+    allows, each in a random quality at or above the Minimum Quality, with a
+    potion icon colour-matched to that quality (ns.LOOT_TOAST_SAMPLE_ICONS).
+    The preview does three jobs at once: it shows where the stack will sit and
+    how many rows it holds, what the chosen font and size look like, and which
+    tiers the Minimum Quality setting is letting through.
+
+    Samples are cleared and rebuilt on every appearance change, and the re-roll
+    is deliberate: the reshuffled colours make the preview visibly answer each
+    change instead of sitting static. Samples never fade; they are released
+    outright when the handle goes away.
+]]
+
+local function ReleaseSamples()
+	-- ReleaseLootToast takes the frame out of `samples` itself, so drain the tail.
+	while #samples > 0 do
+		ns.ReleaseLootToast(samples[#samples])
+	end
+end
+
+--[[
+    Called when the player changes the cap. Trimming here rather than waiting for
+    the next loot means the setting they just picked is the one on screen while
+    they are still looking at it.
+]]
+function ns.ApplyLootToastLimit()
+	while #active > MaxVisible() do
+		ns.ReleaseLootToast(active[1])
+	end
+	ns.RefreshLootToastSamples()
+end
+
+function ns.RefreshLootToastSamples()
+	ReleaseSamples()
+	ApplyHandleLayout()
+	-- Restack still runs when the handle is locked, so a growth, alignment, font,
+	-- or size change with real toasts on screen re-hangs and re-measures them too.
+	if ns.db and ns.AreLootToastsUnlocked() then
+		local rows = MaxVisible()
+		if rows == math.huge then
+			rows = SAMPLE_COUNT_UNLIMITED
+		end
+		local lowestQuality = ns.db.profile.lootToastThreshold
+		for _ = 1, rows do
+			-- 5 is Legendary, the top of ns.LOOT_TOAST_SAMPLE_ICONS.
+			local quality = math.random(lowestQuality, 5)
+			local toast = AcquireToast()
+			toast.icon:SetTexture(ns.LOOT_TOAST_SAMPLE_ICONS[quality])
+			toast.text:SetText(ITEM_QUALITY_COLORS[quality].hex .. ns.L["OPTIONS_TOASTS_EXAMPLE_ITEM"] .. "|r")
+			toast:SetAlpha(1)
+			toast:Show()
+			active[#active + 1] = toast
+			samples[#samples + 1] = toast
+		end
+	end
+	Restack()
+end

--- a/Features/Minimap-Button.lua
+++ b/Features/Minimap-Button.lua
@@ -12,6 +12,9 @@ local GetColor = ns.GetColor
 
 local brokerObj
 
+-- Matches the tooltip's own line height, so an icon sits on the text baseline.
+local TOOLTIP_ICON_SIZE = 16
+
 --------------------------------------------------------------------------------
 -- Icon State
 --------------------------------------------------------------------------------
@@ -29,19 +32,20 @@ function ns:UpdateMinimapIcon()
 		ns.isEnabled and (ns.isPaused and L["STATUS_PAUSED"] or L["STATUS_ENABLED"]) or L["STATUS_DISABLED"]
 	)
 
-	if ns.db and ns.db.global.minimap then
-		LDBIcon:Refresh(ADDON_NAME, ns.db.global.minimap)
+	if ns.db and ns.db.profile.minimap then
+		LDBIcon:Refresh(ADDON_NAME, ns.db.profile.minimap)
 	end
 end
 
 --[[
-    ns.db.global.minimap holds both the button's saved position and its `hide`
-    flag. It is account-wide and profile-independent, so switching, resetting, or
-    deleting a profile never affects the button's visibility or position. The
-    subtable is passed directly to LibDBIcon, which reads `hide` to show or hide.
+    ns.db.profile.minimap holds both the button's saved position and its `hide`
+    flag, and is passed directly to LibDBIcon, which reads `hide` to show or
+    hide. It is profile state under the Simple model, so switching or resetting
+    a profile changes it; UpdateMinimapIcon's Refresh above re-binds the live
+    subtable on those callbacks, so the change applies without a reload.
 ]]
 function ns:SetMinimapShown(shown)
-	ns.db.global.minimap.hide = not shown
+	ns.db.profile.minimap.hide = not shown
 	if shown then
 		LDBIcon:Show(ADDON_NAME)
 	else
@@ -107,10 +111,34 @@ local function ShowTooltip(anchor)
 	tooltip:AddLine(" ")
 	tooltip:AddLine(" ")
 
+	--[[
+        Locked Items leads the tooltip, above the feature blocks, and appears only
+        when boxes are actually waiting. It is the one part that changes with the
+        bags rather than with a setting, so it is what the player opened the
+        tooltip to check; the tooltip re-renders in place after a toggle click, so
+        the list stays live.
+
+        One line per distinct box, icon then name, with a stack count appended only
+        when there is more than one - so no locale needs a plural form. The name
+        comes from the item's own link, already localized and quality-coloured,
+        with the link's brackets stripped since a tooltip line is not running text.
+    ]]
+	local lockedBoxes = ns.GetLockedBoxes()
+	if #lockedBoxes > 0 then
+		tooltip:AddLine(GetColor("TITLE") .. L["TOOLTIP_LOCKED_ITEMS"] .. "|r")
+		for _, row in ipairs(lockedBoxes) do
+			local icon = row.icon and ("|T" .. row.icon .. ":" .. TOOLTIP_ICON_SIZE .. "|t ") or ""
+			local name = row.link and (row.link:gsub("|h%[(.-)%]|h", "|h%1|h"))
+				or (GetColor("TEXT") .. row.itemId .. "|r")
+			tooltip:AddLine(icon .. name .. (row.count > 1 and (" x" .. row.count) or ""))
+		end
+		tooltip:AddLine(" ")
+	end
+
 	-- Auto-Opening
 	tooltip:AddDoubleLine(GetColor("TITLE") .. L["AUTO_OPENING"] .. "|r", GetStatusText(ns.isEnabled, ns.isPaused))
 	tooltip:AddLine(
-		GetColor("BODY") .. string.format(L["AUTO_OPENING_DESC"], ns.MIN_FREE_SLOTS) .. "|r",
+		GetColor("BODY") .. string.format(L["AUTO_OPENING_DESCRIPTION"], ns.MIN_FREE_SLOTS) .. "|r",
 		nil,
 		nil,
 		nil,
@@ -120,11 +148,12 @@ local function ShowTooltip(anchor)
 		GetColor("INFO") .. L["KEYBIND_LEFT_CLICK"] .. "|r",
 		GetColor("INFO") .. L["ACTION_TOGGLE"] .. "|r"
 	)
+
 	tooltip:AddLine(" ")
 
 	-- Speedy Loot
 	tooltip:AddDoubleLine(GetColor("TITLE") .. L["SPEEDY_LOOT"] .. "|r", GetStatusText(ns.isSpeedyLoot, false))
-	tooltip:AddLine(GetColor("BODY") .. L["SPEEDY_LOOT_DESC"] .. "|r", nil, nil, nil, true)
+	tooltip:AddLine(GetColor("BODY") .. L["SPEEDY_LOOT_DESCRIPTION"] .. "|r", nil, nil, nil, true)
 	tooltip:AddDoubleLine(
 		GetColor("INFO") .. L["KEYBIND_RIGHT_CLICK"] .. "|r",
 		GetColor("INFO") .. L["ACTION_TOGGLE"] .. "|r"
@@ -133,7 +162,7 @@ local function ShowTooltip(anchor)
 
 	-- Loot Sounds
 	tooltip:AddDoubleLine(GetColor("TITLE") .. L["LOOT_SOUNDS"] .. "|r", GetStatusText(ns.db.profile.lootSounds, false))
-	tooltip:AddLine(GetColor("BODY") .. L["LOOT_SOUNDS_DESC"] .. "|r", nil, nil, nil, true)
+	tooltip:AddLine(GetColor("BODY") .. L["LOOT_SOUNDS_DESCRIPTION"] .. "|r", nil, nil, nil, true)
 	tooltip:AddDoubleLine(
 		GetColor("INFO") .. L["KEYBIND_MIDDLE_CLICK"] .. "|r",
 		GetColor("INFO") .. L["ACTION_TOGGLE"] .. "|r"
@@ -155,7 +184,7 @@ function ns:InitMinimap()
 		type = "launcher",
 		label = L["ADDON_TITLE"],
 		icon = ns.ICONS["on"],
-		OnClick = function(self, button)
+		OnClick = function(buttonFrame, button)
 			-- Shift + Middle-Click always opens the options panel; checked first.
 			if button == "MiddleButton" and IsShiftKeyDown() then
 				ns:OpenOptionsPanel()
@@ -170,17 +199,17 @@ function ns:InitMinimap()
 				ToggleLootSounds()
 			end
 
-			if GameTooltip:GetOwner() == self then
-				ShowTooltip(self)
+			if GameTooltip:GetOwner() == buttonFrame then
+				ShowTooltip(buttonFrame)
 			end
 		end,
-		OnEnter = function(self)
-			ShowTooltip(self)
+		OnEnter = function(buttonFrame)
+			ShowTooltip(buttonFrame)
 		end,
-		OnLeave = function(self)
+		OnLeave = function()
 			GameTooltip:Hide()
 		end,
 	})
 
-	LDBIcon:Register(ADDON_NAME, brokerObj, ns.db.global.minimap)
+	LDBIcon:Register(ADDON_NAME, brokerObj, ns.db.profile.minimap)
 end

--- a/Features/Speedy-Loot.lua
+++ b/Features/Speedy-Loot.lua
@@ -1,54 +1,28 @@
 local _, ns = ...
 
 --------------------------------------------------------------------------------
--- Libraries
+-- Loot API
 --------------------------------------------------------------------------------
 
-local L = ns.L
+local GetCVarBool = C_CVar.GetCVarBool
 
---------------------------------------------------------------------------------
--- API Compatibility
---------------------------------------------------------------------------------
-
---[[
-    Pick the auto-loot CVar API by availability, not by truthy result. The
-    previous `(modern call) or (legacy call)` pattern fell through to the
-    legacy check whenever the modern API returned false (auto-loot off).
-]]
-local IsAutoLootEnabled
-if C_CVar and C_CVar.GetCVarBool then
-	IsAutoLootEnabled = function()
-		return C_CVar.GetCVarBool("autoLootDefault")
-	end
-else
-	IsAutoLootEnabled = function()
-		return GetCVar("autoLootDefault") == "1"
-	end
+local function IsAutoLootEnabled()
+	return GetCVarBool("autoLootDefault")
 end
 
 --[[
-    Returns (method, masterLooterPartyID). The legacy GetLootMethod returns the
-    method as a string ("master", ...); C_PartyInfo.GetLootMethod returns it as an
-    enum NUMBER. Enum.LootMethod is nil on some Classic builds (2.5.5), so map the
-    enum to the legacy string form, falling back to its numeric value 2 for master.
+    Loot method comes back as a NUMBER on both target clients — the string-
+    returning GetLootMethod global is gone from Era and TBC alike. Enum.LootMethod
+    is not guaranteed to exist on these builds, so the master-loot value is
+    written out as the literal the API actually returns. Diagnostics' Loot Method
+    report prints the live return values and their types, which is what proves
+    this mapping rather than an existence check.
 ]]
-local GetLootMethodCompat
-if type(GetLootMethod) == "function" then
-	GetLootMethodCompat = function()
-		return GetLootMethod()
-	end
-elseif C_PartyInfo and C_PartyInfo.GetLootMethod then
-	GetLootMethodCompat = function()
-		local methodEnum, masterLooterPartyID = C_PartyInfo.GetLootMethod()
-		if (Enum and Enum.LootMethod and methodEnum == Enum.LootMethod.MasterLoot) or methodEnum == 2 then
-			return "master", masterLooterPartyID
-		end
-		return methodEnum, masterLooterPartyID
-	end
-else
-	GetLootMethodCompat = function()
-		return "freeforall"
-	end
+local LOOT_METHOD_MASTER = 2
+
+local function IsPlayerMasterLooter()
+	local method, masterLooterPartyID = C_PartyInfo.GetLootMethod()
+	return method == LOOT_METHOD_MASTER and masterLooterPartyID == 0
 end
 
 --------------------------------------------------------------------------------
@@ -57,14 +31,10 @@ end
 
 --[[
     Money and currency slots take no bag space, so they must never count against
-    the free-slot budget. When GetLootSlotType is unavailable, treat every slot
-    as an item (conservative: counts against the budget).
+    the free-slot budget.
 ]]
 local function IsItemLootSlot(slot)
-	if type(GetLootSlotType) ~= "function" then
-		return true
-	end
-	return GetLootSlotType(slot) == (LOOT_SLOT_ITEM or 1)
+	return GetLootSlotType(slot) == LOOT_SLOT_ITEM
 end
 
 --------------------------------------------------------------------------------
@@ -129,8 +99,7 @@ function ns.HandleSpeedyLoot()
         threshold item also pops MasterLooterFrame_Show with no
         selectedLootButton, which crashes on a nil colorInfo on some clients.
     ]]
-	local lootMethod, masterLooterPartyID = GetLootMethodCompat()
-	if lootMethod == "master" and masterLooterPartyID == 0 then
+	if IsPlayerMasterLooter() then
 		return
 	end
 
@@ -177,13 +146,11 @@ function ns.HandleSpeedyLoot()
 
 			if link then
 				local itemId = tonumber(link:match("item:(%d+)"))
-				if itemId and ns.IgnoreItems and ns.IgnoreItems[itemId] then
+				if ns:IsIgnored(itemId) then
 					shouldLoot = false
 
-					local lastAnnounced = ns.state.recentAnnouncements[itemId] or 0
-					if (now - lastAnnounced) > 5 and ns.db.profile.autoOpen and ns.db.profile.lockboxNotifications then
-						ns:PrintMessage(string.format(L["ITEM_OPEN_MANUALLY"], link))
-						ns.state.recentAnnouncements[itemId] = now
+					if ns.db.profile.ignoreListNotifications then
+						ns:AnnounceItemOnce("ITEM_OPEN_MANUALLY", itemId, link)
 					end
 
 					--[[

--- a/Features/Utilities.lua
+++ b/Features/Utilities.lua
@@ -5,19 +5,18 @@ local _, ns = ...
 --------------------------------------------------------------------------------
 
 --[[
-    Pick each container call by availability: C_Container on modern builds, the
-    identically-named legacy global where the namespace (or a member) is absent.
-    The (C_Container and ...) guard is what makes the fallback reachable —
-    indexing a nil C_Container would error before `or` reached the legacy global,
-    which is the very client the fallback is for. These select a function
-    reference rather than calling it, so the `or` is free of the truthy-
-    fallthrough trap that bans `or` between call results.
+    Both target clients (Classic Era 1.15.x, TBC Anniversary 2.5.x) ship the
+    C_Container namespace and have already removed the identically-named legacy
+    globals, so there is nothing to select between: these are cached function
+    references, unguarded. Diagnostics' API Endpoints report probes each one, so
+    a future client that drops a member shows up as a FAIL row rather than as a
+    silently dead fallback.
 ]]
-ns.GetContainerNumSlots = (C_Container and C_Container.GetContainerNumSlots) or GetContainerNumSlots
-ns.UseContainerItem = (C_Container and C_Container.UseContainerItem) or UseContainerItem
-ns.GetContainerItemLink = (C_Container and C_Container.GetContainerItemLink) or GetContainerItemLink
-ns.GetContainerItemID = (C_Container and C_Container.GetContainerItemID) or GetContainerItemID
-ns.GetContainerNumFreeSlots = (C_Container and C_Container.GetContainerNumFreeSlots) or GetContainerNumFreeSlots
+ns.GetContainerNumSlots = C_Container.GetContainerNumSlots
+ns.UseContainerItem = C_Container.UseContainerItem
+ns.GetContainerItemLink = C_Container.GetContainerItemLink
+ns.GetContainerItemID = C_Container.GetContainerItemID
+ns.GetContainerNumFreeSlots = C_Container.GetContainerNumFreeSlots
 
 --------------------------------------------------------------------------------
 -- Colors
@@ -35,12 +34,192 @@ for key, hex in pairs(ns.PALETTE) do
 	COLORS[key] = COLOR_PREFIX .. hex
 end
 
+--[[
+    The coin colours get the same treatment from their own table. They are kept
+    apart from the palette above because they are not the add-on's to choose: gold,
+    silver and copper look the way the client makes them look everywhere else.
+]]
+local MONEY_COLORS = {}
+for key, hex in pairs(ns.MONEY_PALETTE) do
+	MONEY_COLORS[key] = COLOR_PREFIX .. hex
+end
+
 --------------------------------------------------------------------------------
 -- Utility Functions
 --------------------------------------------------------------------------------
 
 function ns.GetColor(key)
 	return COLORS[key] or COLORS.TEXT
+end
+
+--[[
+    GetSpellInfo has two documented shapes - the classic multiple returns with
+    the name first, and a single info table on newer builds. Read both rather
+    than betting on one, and return nil when the client's spell database has
+    nothing to say, which every caller already treats as unknown.
+
+    Lockbox-Tooltips is the caller: the localized name of the Lockpicking skill
+    is the name of the skill spell, and that is the only way to find the player's
+    rank in a client that publishes no LOCKPICKING global.
+]]
+function ns.GetSpellName(spellID)
+	local info = GetSpellInfo(spellID)
+	if type(info) == "table" then
+		return info.name
+	end
+	return info
+end
+
+--------------------------------------------------------------------------------
+-- Lockbox Feature Scope
+--------------------------------------------------------------------------------
+
+--[[
+    Both lockbox features carry a scope alongside their toggle: "ROGUES" shows
+    them only to a Rogue, "ALL" to everyone. A non-Rogue cannot pick a lock, so
+    Rogues-only is the default for both.
+
+    The predicates live here rather than in either feature file because three
+    files ask the question: Core and Speedy-Loot for the notifications,
+    Lockbox-Tooltips for the tooltip line.
+]]
+function ns.IsPlayerRogue()
+	return select(2, UnitClass("player")) == "ROGUE"
+end
+
+local function ScopeAllows(scope)
+	return scope ~= "ROGUES" or ns.IsPlayerRogue()
+end
+
+function ns.LockboxTooltipsEnabled()
+	return ns.db ~= nil and ns.db.profile.lockboxTooltips and ScopeAllows(ns.db.profile.lockboxTooltipsScope)
+end
+
+function ns.LockboxNotificationsEnabled()
+	return ns.db ~= nil and ns.db.profile.lockboxNotifications and ScopeAllows(ns.db.profile.lockboxNotificationsScope)
+end
+
+--------------------------------------------------------------------------------
+-- Client Format Strings
+--------------------------------------------------------------------------------
+
+--[[
+    Turns one of the client's own format strings into a Lua pattern that captures
+    what the client would have filled in. This is how the add-on reads the game's
+    words in any locale without shipping a translation of them: ITEM_MIN_SKILL
+    becomes the requirement line's skill and number, GOLD_AMOUNT becomes the coin
+    count in a loot message.
+
+    Escape the magic characters first, deliberately leaving % alone so the format's
+    own %s and %d survive to become captures on the next two lines. Matching a
+    literal %s needs the pattern "%%s", not "%%%%s".
+]]
+function ns.BuildFormatPattern(format)
+	if not format then
+		return nil
+	end
+	local pattern = format:gsub("([%^%$%(%)%.%[%]%*%+%-%?])", "%%%1")
+	pattern = pattern:gsub("%%s", "(.+)")
+	pattern = pattern:gsub("%%d", "(%%d+)")
+	return pattern
+end
+
+--------------------------------------------------------------------------------
+-- Money
+--------------------------------------------------------------------------------
+
+local goldPattern = ns.BuildFormatPattern(GOLD_AMOUNT)
+local silverPattern = ns.BuildFormatPattern(SILVER_AMOUNT)
+local copperPattern = ns.BuildFormatPattern(COPPER_AMOUNT)
+
+--[[
+    Reads a coin total out of a loot message ("You loot 1 Gold 24 Silver 7
+    Copper"). The client hands over the sentence, not the number, so the number
+    has to come back out of it -- and matching against the client's OWN
+    GOLD_AMOUNT / SILVER_AMOUNT / COPPER_AMOUNT formats is what makes that work in
+    every locale rather than only in English. A unit the message does not mention
+    simply does not match, which is the same as none of it.
+]]
+function ns.ParseMoney(message)
+	if not message then
+		return 0
+	end
+	local gold = goldPattern and tonumber(message:match(goldPattern)) or 0
+	local silver = silverPattern and tonumber(message:match(silverPattern)) or 0
+	local copper = copperPattern and tonumber(message:match(copperPattern)) or 0
+	return (gold * ns.COPPER_PER_GOLD) + (silver * ns.COPPER_PER_SILVER) + copper
+end
+
+--[[
+    One coin: the amount in body white, then its unit in that coin's own colour.
+    Splitting the colour at the letter is what makes a stack of these readable --
+    the numbers line up as one column of white, and the eye picks the unit off the
+    colour without reading the letter at all.
+
+    The symbol is the client's own, so this reads right in a locale that does not
+    call them gold, silver and copper.
+]]
+local function Coin(amount, digits, symbol, colorKey)
+	return COLORS.BODY .. string.format(digits, amount) .. "|r" .. MONEY_COLORS[colorKey] .. symbol .. "|r"
+end
+
+--[[
+    "123g 02s 27c" - the largest unit the amount reaches, then every unit below it
+    padded to two digits, and nothing above it. Padding only the lower units is
+    what lines the numbers up when several toasts stack, while a leading "0g" on
+    small change would be noise.
+]]
+function ns.FormatMoney(copper)
+	copper = copper or 0
+	local gold = math.floor(copper / ns.COPPER_PER_GOLD)
+	local silver = math.floor((copper % ns.COPPER_PER_GOLD) / ns.COPPER_PER_SILVER)
+	local remainder = copper % ns.COPPER_PER_SILVER
+	if gold > 0 then
+		return Coin(gold, "%d", GOLD_AMOUNT_SYMBOL, "GOLD")
+			.. " "
+			.. Coin(silver, "%02d", SILVER_AMOUNT_SYMBOL, "SILVER")
+			.. " "
+			.. Coin(remainder, "%02d", COPPER_AMOUNT_SYMBOL, "COPPER")
+	end
+	if silver > 0 then
+		return Coin(silver, "%d", SILVER_AMOUNT_SYMBOL, "SILVER")
+			.. " "
+			.. Coin(remainder, "%02d", COPPER_AMOUNT_SYMBOL, "COPPER")
+	end
+	return Coin(remainder, "%d", COPPER_AMOUNT_SYMBOL, "COPPER")
+end
+
+--[[
+    The coin pile matches what the amount actually is, so the icon carries the
+    magnitude before the digits are read: a gold pile for anything reaching gold,
+    silver for anything reaching silver, coppers for the rest.
+]]
+function ns.MoneyIcon(copper)
+	if (copper or 0) >= ns.COPPER_PER_GOLD then
+		return ns.MONEY_ICON_GOLD
+	end
+	if (copper or 0) >= ns.COPPER_PER_SILVER then
+		return ns.MONEY_ICON_SILVER
+	end
+	return ns.MONEY_ICON_COPPER
+end
+
+--------------------------------------------------------------------------------
+-- Utility Functions
+--------------------------------------------------------------------------------
+
+--[[
+    An item link's colour is the only quality signal available without a
+    GetItemInfo round trip, and ns.QUALITY_COLORS maps it. Returns nil for a
+    colour the table does not carry (quest yellow, say) - callers decide whether
+    unknown means show or stay quiet.
+]]
+function ns.GetLinkQuality(link)
+	local colorSequence = link and link:match("|c(%x+)|H")
+	if not colorSequence or #colorSequence ~= 8 then
+		return nil
+	end
+	return ns.QUALITY_COLORS[string.lower(string.sub(colorSequence, 3, 8))]
 end
 
 function ns.GetFreeSlots()

--- a/Includes/Libraries/LibSharedMedia-3.0/LibSharedMedia-3.0.lua
+++ b/Includes/Libraries/LibSharedMedia-3.0/LibSharedMedia-3.0.lua
@@ -1,0 +1,331 @@
+--@curseforge-project-slug: libsharedmedia-3-0@
+--[[
+Name: LibSharedMedia-3.0
+Revision: $Revision: 176 $
+Author: Elkano (elkano@gmx.de)
+Inspired By: SurfaceLib by Haste/Otravi (troeks@gmail.com)
+Website: https://www.curseforge.com/wow/addons/libsharedmedia-3-0
+Description: Shared handling of media data (fonts, sounds, textures, ...) between addons.
+Dependencies: LibStub, CallbackHandler-1.0
+License: LGPL v2.1
+]]
+
+local MAJOR, MINOR = "LibSharedMedia-3.0", 12000002 -- 12.0.0 v2 / increase manually on changes
+local lib = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not lib then return end
+
+local _G = getfenv(0)
+
+local pairs         = _G.pairs
+local type          = _G.type
+
+local band          = _G.bit.band
+local math_floor    = _G.math.floor
+local table_insert  = _G.table.insert
+local table_sort    = _G.table.sort
+
+local locale = GetLocale()
+local locale_is_western
+local LOCALE_MASK
+lib.LOCALE_BIT_koKR     = 1
+lib.LOCALE_BIT_ruRU     = 2
+lib.LOCALE_BIT_zhCN     = 4
+lib.LOCALE_BIT_zhTW     = 8
+lib.LOCALE_BIT_western  = 128
+
+local CallbackHandler = LibStub:GetLibrary("CallbackHandler-1.0")
+
+lib.callbacks       = lib.callbacks     or CallbackHandler:New(lib)
+
+lib.DefaultMedia    = lib.DefaultMedia  or {}
+lib.MediaList       = lib.MediaList     or {}
+lib.MediaTable      = lib.MediaTable    or {}
+lib.MediaType       = lib.MediaType     or {}
+lib.OverrideMedia   = lib.OverrideMedia or {}
+
+local defaultMedia = lib.DefaultMedia
+local mediaList = lib.MediaList
+local mediaTable = lib.MediaTable
+local overrideMedia = lib.OverrideMedia
+
+
+-- create mediatype constants
+lib.MediaType.BACKGROUND    = "background"  -- background textures
+lib.MediaType.BORDER        = "border"      -- border textures
+lib.MediaType.FONT          = "font"        -- fonts
+lib.MediaType.STATUSBAR     = "statusbar"   -- statusbar textures
+lib.MediaType.SOUND         = "sound"       -- sound files
+
+-- populate lib with default Blizzard data
+-- BACKGROUND
+if not lib.MediaTable.background then lib.MediaTable.background = {} end
+lib.MediaTable.background["None"]                               = [[]]
+lib.MediaTable.background["Blizzard Collections Background"]    = [[Interface\Collections\CollectionsBackgroundTile]]
+lib.MediaTable.background["Blizzard Dialog Background"]         = [[Interface\DialogFrame\UI-DialogBox-Background]]
+lib.MediaTable.background["Blizzard Dialog Background Dark"]    = [[Interface\DialogFrame\UI-DialogBox-Background-Dark]]
+lib.MediaTable.background["Blizzard Dialog Background Gold"]    = [[Interface\DialogFrame\UI-DialogBox-Gold-Background]]
+lib.MediaTable.background["Blizzard Garrison Background"]       = [[Interface\Garrison\GarrisonUIBackground]]
+lib.MediaTable.background["Blizzard Garrison Background 2"]     = [[Interface\Garrison\GarrisonUIBackground2]]
+lib.MediaTable.background["Blizzard Garrison Background 3"]     = [[Interface\Garrison\GarrisonMissionUIInfoBoxBackgroundTile]]
+lib.MediaTable.background["Blizzard Low Health"]                = [[Interface\FullScreenTextures\LowHealth]]
+lib.MediaTable.background["Blizzard Marble"]                    = [[Interface\FrameGeneral\UI-Background-Marble]]
+lib.MediaTable.background["Blizzard Out of Control"]            = [[Interface\FullScreenTextures\OutOfControl]]
+lib.MediaTable.background["Blizzard Parchment"]                 = [[Interface\AchievementFrame\UI-Achievement-Parchment-Horizontal]]
+lib.MediaTable.background["Blizzard Parchment 2"]               = [[Interface\AchievementFrame\UI-GuildAchievement-Parchment-Horizontal]]
+lib.MediaTable.background["Blizzard Rock"]                      = [[Interface\FrameGeneral\UI-Background-Rock]]
+lib.MediaTable.background["Blizzard Tabard Background"]         = [[Interface\TabardFrame\TabardFrameBackground]]
+lib.MediaTable.background["Blizzard Tooltip"]                   = [[Interface\Tooltips\UI-Tooltip-Background]]
+lib.MediaTable.background["Solid"]                              = [[Interface\Buttons\WHITE8X8]]
+lib.DefaultMedia.background = "None"
+
+-- BORDER
+if not lib.MediaTable.border then lib.MediaTable.border = {} end
+lib.MediaTable.border["None"]                       = [[]]
+lib.MediaTable.border["Blizzard Achievement Wood"]  = [[Interface\AchievementFrame\UI-Achievement-WoodBorder]]
+lib.MediaTable.border["Blizzard Chat Bubble"]       = [[Interface\Tooltips\ChatBubble-Backdrop]]
+lib.MediaTable.border["Blizzard Dialog"]            = [[Interface\DialogFrame\UI-DialogBox-Border]]
+lib.MediaTable.border["Blizzard Dialog Gold"]       = [[Interface\DialogFrame\UI-DialogBox-Gold-Border]]
+lib.MediaTable.border["Blizzard Party"]             = [[Interface\CHARACTERFRAME\UI-Party-Border]]
+lib.MediaTable.border["Blizzard Tooltip"]           = [[Interface\Tooltips\UI-Tooltip-Border]]
+lib.DefaultMedia.border = "None"
+
+-- FONT
+if not lib.MediaTable.font then lib.MediaTable.font = {} end
+local SML_MT_font = lib.MediaTable.font
+--[[
+All font files are currently in all clients, the following table depicts which font supports which charset as of 5.0.4
+Fonts were checked using langcover.pl from DejaVu fonts (http://sourceforge.net/projects/dejavu/) and FontForge (http://fontforge.org/)
+latin means check for: de, en, es, fr, it, pt
+
+file                name                            latin   koKR    ruRU    zhCN    zhTW
+2002.ttf            2002                            X       X       X       -       -
+2002B.ttf           2002 Bold                       X       X       X       -       -
+ARHei.ttf           AR CrystalzcuheiGBK Demibold    X       -       X       X       X
+ARIALN.TTF          Arial Narrow                    X       -       X       -       -
+ARKai_C.ttf         AR ZhongkaiGBK Medium (Combat)  X       -       X       X       X
+ARKai_T.ttf         AR ZhongkaiGBK Medium           X       -       X       X       X
+bHEI00M.ttf         AR Heiti2 Medium B5             -       -       -       -       X
+bHEI01B.ttf         AR Heiti2 Bold B5               -       -       -       -       X
+bKAI00M.ttf         AR Kaiti Medium B5              -       -       -       -       X
+bLEI00D.ttf         AR Leisu Demi B5                -       -       -       -       X
+FRIZQT__.TTF        Friz Quadrata TT                X       -       -       -       -
+FRIZQT___CYR.TTF    FrizQuadrataCTT                 x       -       X       -       -
+K_Damage.TTF        YDIWingsM                       -       X       X       -       -
+K_Pagetext.TTF      MoK                             X       X       X       -       -
+MORPHEUS.TTF        Morpheus                        X       -       -       -       -
+MORPHEUS_CYR.TTF    Morpheus                        X       -       X       -       -
+NIM_____.ttf        Nimrod MT                       X       -       X       -       -
+SKURRI.TTF          Skurri                          X       -       -       -       -
+SKURRI_CYR.TTF      Skurri                          X       -       X       -       -
+
+WARNING: Although FRIZQT___CYR is available on western clients, it doesn't support special European characters e.g. é, ï, ö
+Due to this, we cannot use it as a replacement for FRIZQT__.TTF
+]]
+
+if locale == "koKR" then
+    LOCALE_MASK = lib.LOCALE_BIT_koKR
+--
+    SML_MT_font["굵은 글꼴"]    = [[Fonts\2002B.TTF]]
+    SML_MT_font["기본 글꼴"]    = [[Fonts\2002.TTF]]
+    SML_MT_font["데미지 글꼴"]  = [[Fonts\K_Damage.TTF]]
+    SML_MT_font["퀘스트 글꼴"]  = [[Fonts\K_Pagetext.TTF]]
+--
+    lib.DefaultMedia["font"] = "기본 글꼴" -- someone from koKR please adjust if needed
+--
+elseif locale == "zhCN" then
+    LOCALE_MASK = lib.LOCALE_BIT_zhCN
+--
+    SML_MT_font["伤害数字"] = [[Fonts\ARKai_C.ttf]]
+    SML_MT_font["默认"]     = [[Fonts\ARKai_T.ttf]]
+    SML_MT_font["聊天"]     = [[Fonts\ARHei.ttf]]
+--
+    lib.DefaultMedia["font"] = "默认" -- someone from zhCN please adjust if needed
+--
+elseif locale == "zhTW" then
+    LOCALE_MASK = lib.LOCALE_BIT_zhTW
+--
+    SML_MT_font["提示訊息"] = [[Fonts\bHEI00M.ttf]]
+    SML_MT_font["聊天"]     = [[Fonts\bHEI01B.ttf]]
+    SML_MT_font["傷害數字"] = [[Fonts\bKAI00M.ttf]]
+    SML_MT_font["預設"]     = [[Fonts\bLEI00D.ttf]]
+--
+    lib.DefaultMedia["font"] = "預設" -- someone from zhTW please adjust if needed
+
+elseif locale == "ruRU" then
+    LOCALE_MASK = lib.LOCALE_BIT_ruRU
+--
+    SML_MT_font["2002"]                             = [[Fonts\2002.TTF]]
+    SML_MT_font["2002 Bold"]                        = [[Fonts\2002B.TTF]]
+    SML_MT_font["AR CrystalzcuheiGBK Demibold"]     = [[Fonts\ARHei.TTF]]
+    SML_MT_font["AR ZhongkaiGBK Medium (Combat)"]   = [[Fonts\ARKai_C.TTF]]
+    SML_MT_font["AR ZhongkaiGBK Medium"]            = [[Fonts\ARKai_T.TTF]]
+    SML_MT_font["Arial Narrow"]                     = [[Fonts\ARIALN.TTF]]
+    SML_MT_font["Friz Quadrata TT"]                 = [[Fonts\FRIZQT___CYR.TTF]]
+    SML_MT_font["MoK"]                              = [[Fonts\K_Pagetext.TTF]]
+    SML_MT_font["Morpheus"]                         = [[Fonts\MORPHEUS_CYR.TTF]]
+    SML_MT_font["Nimrod MT"]                        = [[Fonts\NIM_____.ttf]]
+    SML_MT_font["Skurri"]                           = [[Fonts\SKURRI_CYR.TTF]]
+--
+    lib.DefaultMedia.font = "Friz Quadrata TT"
+--
+else
+    LOCALE_MASK = lib.LOCALE_BIT_western
+    locale_is_western = true
+--
+    SML_MT_font["2002"]                             = [[Fonts\2002.TTF]]
+    SML_MT_font["2002 Bold"]                        = [[Fonts\2002B.TTF]]
+    SML_MT_font["AR CrystalzcuheiGBK Demibold"]     = [[Fonts\ARHei.TTF]]
+    SML_MT_font["AR ZhongkaiGBK Medium (Combat)"]   = [[Fonts\ARKai_C.TTF]]
+    SML_MT_font["AR ZhongkaiGBK Medium"]            = [[Fonts\ARKai_T.TTF]]
+    SML_MT_font["Arial Narrow"]                     = [[Fonts\ARIALN.TTF]]
+    SML_MT_font["Friz Quadrata TT"]                 = [[Fonts\FRIZQT__.TTF]]
+    SML_MT_font["MoK"]                              = [[Fonts\K_Pagetext.TTF]]
+    SML_MT_font["Morpheus"]                         = [[Fonts\MORPHEUS_CYR.TTF]]
+    SML_MT_font["Nimrod MT"]                        = [[Fonts\NIM_____.ttf]]
+    SML_MT_font["Skurri"]                           = [[Fonts\SKURRI_CYR.TTF]]
+--
+    lib.DefaultMedia.font = "Friz Quadrata TT"
+--
+end
+
+-- STATUSBAR
+if not lib.MediaTable.statusbar then lib.MediaTable.statusbar = {} end
+lib.MediaTable.statusbar["Blizzard"]                        = [[Interface\TargetingFrame\UI-StatusBar]]
+lib.MediaTable.statusbar["Blizzard Character Skills Bar"]   = [[Interface\PaperDollInfoFrame\UI-Character-Skills-Bar]]
+lib.MediaTable.statusbar["Blizzard Raid Bar"]               = [[Interface\RaidFrame\Raid-Bar-Hp-Fill]]
+lib.MediaTable.statusbar["Solid"]                           = [[Interface\Buttons\WHITE8X8]]
+lib.DefaultMedia.statusbar = "Blizzard"
+
+-- SOUND
+if not lib.MediaTable.sound then lib.MediaTable.sound = {} end
+lib.MediaTable.sound["None"] = 1 -- Relies on the fact that PlaySoundFile doesn't error on this value
+lib.DefaultMedia.sound = "None"
+
+local function buildMediaList(mediatype)
+    local mtable = mediaTable[mediatype]
+    if not mtable then return end
+    if not mediaList[mediatype] then mediaList[mediatype] = {} end
+    local mlist = mediaList[mediatype]
+    -- list can only get larger, so simply overwrite it (should be empty anyways)
+    local i = 0
+    for k in pairs(mtable) do
+        i = i + 1
+        mlist[i] = k
+    end
+    table_sort(mlist)
+end
+
+local function updateMediaList(mediatype, value)
+    if not mediaList[mediatype] then
+        -- nothing to update, yet
+        return
+    end
+
+    local mlist = mediaList[mediatype]
+    -- invariant: list is sorted, entries are unique, value not yet in list
+    local s, e, m = 1, #mlist
+    while s <= e do
+        m = math_floor((s + e) / 2)
+        if mlist[m] > value then
+            e = m - 1
+        else
+            s = m + 1
+        end
+    end
+    table_insert(mlist, s, value)
+end
+
+do
+    local IsKnownFile = C_UIFileAsset.IsKnownFile
+    function lib:Register(mediatype, key, data, langmask)
+        if type(mediatype) ~= "string" then
+            error(MAJOR..":Register(mediatype, key, data, langmask) - mediatype must be string, got "..type(mediatype))
+        end
+        if type(key) ~= "string" then
+            error(MAJOR..":Register(mediatype, key, data, langmask) - key must be string, got "..type(key))
+        end
+        mediatype = mediatype:lower()
+        if mediatype == lib.MediaType.FONT and (not IsKnownFile(data) or (langmask and band(langmask, LOCALE_MASK) == 0) or not (langmask or locale_is_western)) then
+            -- ignore fonts that don't exist, or aren't flagged as supporting local glyphs on non-western clients
+            return false
+        end
+        if type(data) == "string" and (mediatype == lib.MediaType.BACKGROUND or mediatype == lib.MediaType.BORDER or mediatype == lib.MediaType.STATUSBAR or mediatype == lib.MediaType.SOUND) then
+            if not IsKnownFile(data) then
+                -- ignore files that don't exist
+                return false
+            end
+            local path = data:lower()
+            if not path:find("^interface") then
+                -- files accessed via path only allowed from interface folder
+                return false
+            end
+            if mediatype == lib.MediaType.SOUND and not (path:find(".ogg", nil, true) or path:find(".mp3", nil, true)) then
+                -- only ogg and mp3 are valid sounds
+                return false
+            end
+        end
+        if not mediaTable[mediatype] then mediaTable[mediatype] = {} end
+        local mtable = mediaTable[mediatype]
+        if mtable[key] then
+            -- key already registered
+            return false
+        end
+
+        mtable[key] = data
+        updateMediaList(mediatype, key)
+        self.callbacks:Fire("LibSharedMedia_Registered", mediatype, key)
+        return true
+    end
+end
+
+function lib:Fetch(mediatype, key, noDefault)
+    local mtt = mediaTable[mediatype]
+    local overridekey = overrideMedia[mediatype]
+    local result = mtt and ((overridekey and mtt[overridekey] or mtt[key]) or (not noDefault and defaultMedia[mediatype] and mtt[defaultMedia[mediatype]])) or nil
+    return result ~= "" and result or nil
+end
+
+function lib:IsValid(mediatype, key)
+    return mediaTable[mediatype] and (not key or mediaTable[mediatype][key]) and true or false
+end
+
+function lib:HashTable(mediatype)
+    return mediaTable[mediatype]
+end
+
+function lib:List(mediatype)
+    if not mediaTable[mediatype] then
+        return nil
+    end
+    if not mediaList[mediatype] then
+        buildMediaList(mediatype)
+    end
+    return mediaList[mediatype]
+end
+
+function lib:GetGlobal(mediatype)
+    return overrideMedia[mediatype]
+end
+
+function lib:SetGlobal(mediatype, key)
+    if not mediaTable[mediatype] then
+        return false
+    end
+    overrideMedia[mediatype] = (key and mediaTable[mediatype][key]) and key or nil
+    self.callbacks:Fire("LibSharedMedia_SetGlobal", mediatype, overrideMedia[mediatype])
+    return true
+end
+
+function lib:GetDefault(mediatype)
+    return defaultMedia[mediatype]
+end
+
+function lib:SetDefault(mediatype, key)
+    if mediaTable[mediatype] and mediaTable[mediatype][key] and not defaultMedia[mediatype] then
+        defaultMedia[mediatype] = key
+        return true
+    else
+        return false
+    end
+end

--- a/Includes/Libraries/LibSharedMedia-3.0/lib.xml
+++ b/Includes/Libraries/LibSharedMedia-3.0/lib.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="LibSharedMedia-3.0.lua" />
+</Ui>

--- a/Locales/deDE.lua
+++ b/Locales/deDE.lua
@@ -13,34 +13,49 @@ L["STATUS_DISABLED"] = "Deaktiviert"
 L["STATUS_PAUSED"] = "Pausiert"
 
 --------------------------------------------------------------------------------
+-- Panel Tabs
+--------------------------------------------------------------------------------
+
+L["TAB_NOTIFICATIONS"] = "Benachrichtigungen"
+L["TAB_LOCKBOXES"] = "Schließfächer"
+L["TAB_IGNORE_LIST"] = "Ignorierliste"
+
+--------------------------------------------------------------------------------
 -- Chat Messages
 --------------------------------------------------------------------------------
 
 -- System
 L["AUTO_LOOT_ENABLED"] = "Automatisches Plündern wurde aktiviert. Open Sesame benötigt es, um zu funktionieren."
+L["CHAT_OPTIONS_IN_COMBAT"] = "Aus Sicherheitsgründen kann die Optionen-Oberfläche im Kampf nicht geöffnet werden."
 L["CHAT_LOADED"] =
-	"Version %s. Einstellungen (einschließlich der Option, diese Nachricht zu deaktivieren) finden Sie unter Optionen > AddOns > Open Sesame. Gefällt dir das Addon? Erzähl einem Freund davon! (="
+	"Version %s. Einstellungen (einschließlich der Option, diese Nachricht zu deaktivieren) findest du unter Optionen > AddOns > Open Sesame. Gefällt dir das Add-on? Erzähl einem Freund davon! (="
 
 -- Auto-Opening
 L["PAUSED_BAG_SLOTS"] = "Das automatische Öffnen ist pausiert, bis mindestens %d Taschenplätze frei sind."
 L["RESUMED"] = "Das automatische Öffnen wurde fortgesetzt."
 L["INVENTORY_FULL"] = "Inventar ist voll!"
 L["ITEM_WILL_AUTO_OPEN"] = "%s wird automatisch geöffnet, sobald es entsperrt ist."
-L["ITEM_OPEN_MANUALLY"] =
-	"%s muss manuell geöffnet werden. Es kann einen einzigartigen, beim Aufheben gebundenen oder temporären Gegenstand enthalten oder wurde von einem Schlachtzugsboss fallengelassen."
+L["ITEM_IGNORED"] = "%s steht auf deiner Ignorierliste, daher hat das automatische Öffnen es in Ruhe gelassen."
+L["ITEM_OPEN_MANUALLY"] = "%s wurde im Beutefenster gelassen, damit du es selbst öffnen kannst."
 
 --------------------------------------------------------------------------------
 -- Features
 --------------------------------------------------------------------------------
 
 L["AUTO_OPENING"] = "Automatisches Öffnen"
-L["AUTO_OPENING_DESC"] =
+L["AUTO_OPENING_DESCRIPTION"] =
 	"Öffnet automatisch Muscheln und entsperrte Behälter, wenn mindestens %d Taschenplätze frei sind."
 L["SPEEDY_LOOT"] = "Schnelle Beute"
-L["SPEEDY_LOOT_DESC"] = "Blendet das Beutefenster aus, um Beute nahezu sofort aufzusammeln."
+L["SPEEDY_LOOT_DESCRIPTION"] = "Blendet das Beutefenster aus, um Beute nahezu sofort aufzusammeln."
+L["NOTIFICATIONS_DESCRIPTION"] =
+	"Die Schnelle Beute blendet das Beutefenster aus, daher teilt dir Open Sesame hierüber mit, was du gerade aufgesammelt hast."
+L["LOCKBOXES_DESCRIPTION"] =
+	"Verschlossene Behälter benötigen die Fertigkeit Schlossknacken eines Schurken, bevor sie sich öffnen lassen. Diese Optionen zeigen, was jedes Schließfach erfordert, und melden dir, wenn eines wartet."
 L["LOOT_SOUNDS"] = "Beutegeräusch"
-L["LOOT_SOUNDS_DESC"] =
-	"Spielt einen besonderen Ton ab, wenn ein Gegenstand ungewöhnlicher oder höherer Qualität erbeutet wird."
+L["LOOT_SOUNDS_DESCRIPTION"] = "Spielt einen Ton ab, abhängig von der Qualitätsstufe deiner Wahl."
+L["LOOT_TOASTS"] = "Beutehinweise"
+L["LOOT_TOASTS_DESCRIPTION"] =
+	"Zeigt einen kurzen Hinweis auf dem Bildschirm für Gegenstände, die du aufsammelst, da die Schnelle Beute das Beutefenster ausblendet. Beute aus dem Chat zu verlagern hält das Fenster frei für Gespräche und die Nachrichten, auf die es ankommt."
 
 --------------------------------------------------------------------------------
 -- Tooltip
@@ -52,24 +67,113 @@ L["KEYBIND_MIDDLE_CLICK"] = "Mittelklick"
 L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + Mittelklick"
 L["ACTION_TOGGLE"] = "Umschalten"
 L["TOOLTIP_OPTIONS_TITLE"] = "Open Sesame Optionen"
+L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"] = "Benötigt Schlossknacken"
+L["TOOLTIP_YOUR_LOCKPICKING_LABEL"] = "Dein Schlossknacken"
+L["TOOLTIP_LOCKED_ITEMS"] = "Verschlossene Gegenstände"
 
 --------------------------------------------------------------------------------
 -- Options
 --------------------------------------------------------------------------------
 
-L["OPTIONS_INTRO"] =
-	"Open Sesame öffnet automatisch Muscheln, Schließfächer und entsperrte Behälter in deinen Taschen. Die integrierte Schnelle Beute blendet das Beutefenster für nahezu sofortiges Aufsammeln aus. Weniger Klicken, mehr Spielen."
+-- General Panel
+L["OPTIONS_DESCRIPTION"] =
+	"Öffnet automatisch Muscheln, Schließfächer und entsperrte Behälter in deinen Taschen, ganz ohne Klicken. Die integrierte Schnelle Beute blendet das Beutefenster für nahezu sofortiges automatisches Aufsammeln aus. Weniger Klicken, mehr Spielen."
 L["OPTIONS_ENABLE_WELCOME"] = "Willkommensnachricht aktivieren"
 L["OPTIONS_ENABLE_MINIMAP"] = "Minikarten-Schaltfläche aktivieren"
-L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Schließfach-Benachrichtigungen aktivieren"
+
+-- Auto-Opening
 L["OPTIONS_ENABLE_AUTO_OPENING"] = "Automatisches Öffnen aktivieren"
+L["OPTIONS_AUTO_OPENING_WHERE"] = "Wo"
+L["OPTIONS_ANYWHERE"] = "Überall"
+L["OPTIONS_OUTSIDE_INSTANCES"] = "Außerhalb von Instanzen"
+L["OPTIONS_AUTO_OPENING_GROUP"] = "Gruppe"
+L["OPTIONS_SOLO_OR_GROUPED"] = "Allein oder in Gruppe"
+L["OPTIONS_SOLO_ONLY"] = "Nur allein"
+
+-- Speedy Loot
 L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "Schnelle Beute aktivieren"
+
+-- Lockboxes
+L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"] = "Schließfach-Tooltips aktivieren"
+L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Schließfach-Benachrichtigungen aktivieren"
+L["OPTIONS_SHOW_FOR"] = "Anzeigen für"
+L["OPTIONS_FOR_ROGUES"] = "Für Schurken"
+L["OPTIONS_FOR_ALL_CHARACTERS"] = "Für alle Charaktere"
+
+-- Notifications
 L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "Beutegeräusch aktivieren"
-L["OPTIONS_LOOT_SOUND_THRESHOLD"] = "Mindestqualität für Beutegeräusch"
 L["OPTIONS_TEST_LOOT_SOUND"] = "Beutegeräusch abspielen."
-L["OPTIONS_COMMANDS_HEADER"] = "/Befehle"
-L["OPTIONS_CMD_OS"] = "/os"
-L["OPTIONS_CMD_OS_DESCRIPTION"] = "Öffnet die Open Sesame Optionen."
+L["OPTIONS_ENABLE_PICK_POCKET_SOUND"] = "Taschendiebstahl-Geräusch aktivieren"
+L["OPTIONS_MINIMUM_QUALITY"] = "Mindestqualität"
+
+-- Loot Toasts
+L["OPTIONS_ENABLE_LOOT_TOASTS"] = "Beutehinweise aktivieren"
+-- The threshold bypasses, then the money row, in the order the panel lists them.
+L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"] = "Beim Aufheben gebundene Gegenstände immer anzeigen"
+L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"] = "Questgegenstände immer anzeigen"
+L["OPTIONS_ALWAYS_SHOW_RECIPES"] = "Rezepte immer anzeigen"
+L["OPTIONS_ALWAYS_SHOW_MOUNTS"] = "Reittiere immer anzeigen"
+L["OPTIONS_ALWAYS_SHOW_PETS"] = "Haustiere immer anzeigen"
+L["OPTIONS_ALWAYS_SHOW_KEYS"] = "Schlüssel immer anzeigen"
+L["OPTIONS_ALWAYS_SHOW_BAGS"] = "Taschen immer anzeigen"
+L["OPTIONS_ALWAYS_SHOW_CONTAINERS"] = "Behälter immer anzeigen"
+L["OPTIONS_ALWAYS_SHOW_MONEY"] = "Gold immer anzeigen"
+L["OPTIONS_LOOT_TOAST_MAX_ITEMS"] = "Maximal angezeigte Einträge"
+L["OPTIONS_UNLIMITED"] = "Unbegrenzt"
+L["OPTIONS_LOOT_TOAST_DURATION"] = "Sekunden auf dem Bildschirm"
+L["OPTIONS_LOOT_TOAST_GROWTH"] = "Wachstumsrichtung"
+L["OPTIONS_GROW_UP"] = "Nach oben"
+L["OPTIONS_GROW_DOWN"] = "Nach unten"
+L["OPTIONS_LOOT_TOAST_ALIGN"] = "Einträge ausrichten"
+L["OPTIONS_ALIGN_LEFT"] = "Links"
+L["OPTIONS_ALIGN_RIGHT"] = "Rechts"
+L["OPTIONS_LOOT_TOAST_FONT"] = "Schriftart"
+L["OPTIONS_FONT_DEFAULT"] = "Standard"
+L["OPTIONS_LOOT_TOAST_FONT_SIZE"] = "Schriftgröße"
+L["OPTIONS_LOOT_TOAST_OUTLINE"] = "Schriftkontur"
+L["OPTIONS_FONT_OUTLINE_NONE"] = "Keine"
+L["OPTIONS_FONT_OUTLINE_OUTLINE"] = "Kontur"
+L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"] = "Dicke Kontur"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME"] = "Einfarbig"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"] = "Einfarbige Kontur"
+L["OPTIONS_TOASTS_UNLOCK"] = "Position entsperren"
+L["OPTIONS_TOASTS_LOCK"] = "Position sperren"
+L["OPTIONS_TOASTS_RESET"] = "Position zurücksetzen"
+L["OPTIONS_TOASTS_CLICK_DRAG"] = "Klicken + Ziehen zum Positionieren"
+L["OPTIONS_TOASTS_RIGHT_CLICK_LOCK"] = "Rechtsklick zum Sperren"
+L["OPTIONS_TOASTS_DISABLE_BUTTON"] = "Beutehinweise deaktivieren"
+L["OPTIONS_TOASTS_EXAMPLE_ITEM"] = "Beispielgegenstand"
+
+-- Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
+L["OPTIONS_COMMAND"] = "/os"
+L["OPTIONS_COMMAND_DESCRIPTION"] = "Öffnet die Optionen-Oberfläche für dieses Add-on."
+
+-- Ignore List
+L["OPTIONS_IGNORE_LIST_DESCRIPTION"] =
+	"Gegenstände auf dieser Liste werden in Ruhe gelassen: Die Schnelle Beute lässt sie im Beutefenster, und das automatische Öffnen öffnet sie nie. Die Liste gilt für alle deine Charaktere."
+L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"] = "Benachrichtigungen zur Ignorierliste aktivieren"
+L["OPTIONS_IGNORE_LIST_ADD"] = "Gegenstand hinzufügen"
+L["OPTIONS_IGNORE_LIST_ADD_HINT"] =
+	"Ziehe einen Gegenstand hierher oder füge einen Gegenstandslink oder eine Gegenstands-ID ein."
+L["OPTIONS_IGNORE_LIST_REMOVE"] = "Diesen Gegenstand von der Ignorierliste entfernen."
+L["OPTIONS_IGNORE_LIST_RESTORE"] = "Standard wiederherstellen"
+L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"] =
+	"Die Standard-Ignorierliste wiederherstellen? Von dir hinzugefügte Einträge werden entfernt."
+L["OPTIONS_IGNORE_REASON_RAID"] =
+	"Beute eines Schlachtzugsbosses. Ein ungeöffneter Behälter kann weiterhin gehandelt oder verkauft werden, oft für mehr als sein Inhalt."
+L["OPTIONS_IGNORE_REASON_QUEST"] =
+	"Kann einen einzigartigen Questgegenstand enthalten. Das Öffnen kann mit einem Fehler fehlschlagen, wenn du bereits einen besitzt."
+L["OPTIONS_IGNORE_REASON_RECIPE"] =
+	"Kann ein beim Aufheben gebundenes Rezept enthalten. Ein ungeöffneter Behälter kann weiterhin gehandelt oder verkauft werden."
+L["OPTIONS_IGNORE_REASON_GEAR"] =
+	"Kann eine beim Aufheben gebundene Waffe oder ein Rüstungsteil enthalten. Ein ungeöffneter Behälter kann weiterhin gehandelt oder verkauft werden."
+L["OPTIONS_IGNORE_REASON_HOLIDAY"] =
+	"Kann einen beim Aufheben gebundenen Feiertagsgegenstand enthalten. Ein ungeöffneter Behälter kann weiterhin gehandelt oder verkauft werden."
+L["OPTIONS_IGNORE_REASON_ITEM"] =
+	"Kann einen beim Aufheben gebundenen Gegenstand enthalten. Ein ungeöffneter Behälter kann weiterhin gehandelt oder verkauft werden."
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Feedback & Unterstützung"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -13,11 +13,20 @@ L["STATUS_DISABLED"] = "Disabled"
 L["STATUS_PAUSED"] = "Paused"
 
 --------------------------------------------------------------------------------
+-- Panel Tabs
+--------------------------------------------------------------------------------
+
+L["TAB_NOTIFICATIONS"] = "Notifications"
+L["TAB_LOCKBOXES"] = "Lockboxes"
+L["TAB_IGNORE_LIST"] = "Ignore List"
+
+--------------------------------------------------------------------------------
 -- Chat Messages
 --------------------------------------------------------------------------------
 
 -- System
 L["AUTO_LOOT_ENABLED"] = "Auto Loot has been enabled. Open Sesame requires it to function."
+L["CHAT_OPTIONS_IN_COMBAT"] = "As a safety precaution, the Options Interface cannot be opened during combat."
 L["CHAT_LOADED"] =
 	"Version %s. Settings (including the option to disable this message) can be found under Options > AddOns > Open Sesame. Enjoying the add-on? Tell a friend about it! (="
 
@@ -26,19 +35,27 @@ L["PAUSED_BAG_SLOTS"] = "Auto-Opening is Paused until you have at least %d empty
 L["RESUMED"] = "Auto-Opening has Resumed."
 L["INVENTORY_FULL"] = "Inventory is full!"
 L["ITEM_WILL_AUTO_OPEN"] = "%s will be automatically opened once it's unlocked."
-L["ITEM_OPEN_MANUALLY"] =
-	"%s needs to be opened manually. It may contain a Unique, Bind on Pickup, or Temporary item; or it was dropped by a raid boss."
+L["ITEM_IGNORED"] = "%s is on your Ignore List, so Auto-Opening left it alone."
+L["ITEM_OPEN_MANUALLY"] = "%s was left in the loot window for you to open yourself."
 
 --------------------------------------------------------------------------------
 -- Features
 --------------------------------------------------------------------------------
 
 L["AUTO_OPENING"] = "Auto-Opening"
-L["AUTO_OPENING_DESC"] = "Automatically opens clams and unlocked containers when you have at least %d empty bag slots."
+L["AUTO_OPENING_DESCRIPTION"] =
+	"Automatically opens clams and unlocked containers when you have at least %d empty bag slots."
 L["SPEEDY_LOOT"] = "Speedy Loot"
-L["SPEEDY_LOOT_DESC"] = "Hides the loot window for near-instant looting."
+L["SPEEDY_LOOT_DESCRIPTION"] = "Hides the loot window for near-instant looting."
+L["NOTIFICATIONS_DESCRIPTION"] =
+	"Speedy Loot hides the loot window, so these are how Open Sesame tells you what you just picked up."
+L["LOCKBOXES_DESCRIPTION"] =
+	"Locked containers need a Rogue's Lockpicking skill before they will open. These options show what each lockbox requires, and tell you when one is waiting."
 L["LOOT_SOUNDS"] = "Loot Sound"
-L["LOOT_SOUNDS_DESC"] = "Plays a distinct sound when you loot an Uncommon or higher quality item."
+L["LOOT_SOUNDS_DESCRIPTION"] = "Plays a sound based on the quality settings of your choice."
+L["LOOT_TOASTS"] = "Loot Toasts"
+L["LOOT_TOASTS_DESCRIPTION"] =
+	"Shows a brief on-screen notice for items you loot, since Speedy Loot hides the loot window. Moving loot out of chat frees the window up for conversation and the messages that matter."
 
 --------------------------------------------------------------------------------
 -- Tooltip
@@ -50,24 +67,111 @@ L["KEYBIND_MIDDLE_CLICK"] = "Middle-Click"
 L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + Middle-Click"
 L["ACTION_TOGGLE"] = "Toggle"
 L["TOOLTIP_OPTIONS_TITLE"] = "Open Sesame Options"
+L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"] = "Requires Lockpicking"
+L["TOOLTIP_YOUR_LOCKPICKING_LABEL"] = "Your Lockpicking"
+L["TOOLTIP_LOCKED_ITEMS"] = "Locked Items"
 
 --------------------------------------------------------------------------------
 -- Options
 --------------------------------------------------------------------------------
 
-L["OPTIONS_INTRO"] =
-	"Automatically open clams, lockboxes, and unlocked containers in your bags, no clicking required. Built-in Speedy Loot hides the loot window for near-instant auto looting. Less time clicking, more time playing."
+-- General Panel
+L["OPTIONS_DESCRIPTION"] =
+	"Automatically open clams and unlocked containers in your bags, no clicking required. Built-in Speedy Loot hides the loot window for near-instant auto looting, and Loot Toasts show every pickup so your eyes stay on the fight. Fast, efficient looting."
 L["OPTIONS_ENABLE_WELCOME"] = "Enable Welcome Message"
 L["OPTIONS_ENABLE_MINIMAP"] = "Enable Mini-map Button"
-L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Enable Lockbox Notifications"
+
+-- Auto-Opening
 L["OPTIONS_ENABLE_AUTO_OPENING"] = "Enable Auto-Opening"
+L["OPTIONS_AUTO_OPENING_WHERE"] = "Where"
+L["OPTIONS_ANYWHERE"] = "Anywhere"
+L["OPTIONS_OUTSIDE_INSTANCES"] = "Outside Instances"
+L["OPTIONS_AUTO_OPENING_GROUP"] = "Group"
+L["OPTIONS_SOLO_OR_GROUPED"] = "Solo or Grouped"
+L["OPTIONS_SOLO_ONLY"] = "Solo Only"
+
+-- Speedy Loot
 L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "Enable Speedy Loot"
+
+-- Lockboxes
+L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"] = "Enable Lockbox Tooltips"
+L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Enable Lockbox Notifications"
+L["OPTIONS_SHOW_FOR"] = "Show for"
+L["OPTIONS_FOR_ROGUES"] = "For Rogues"
+L["OPTIONS_FOR_ALL_CHARACTERS"] = "For All Characters"
+
+-- Notifications
 L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "Enable Loot Sound"
-L["OPTIONS_LOOT_SOUND_THRESHOLD"] = "Minimum Quality for Loot Sound"
 L["OPTIONS_TEST_LOOT_SOUND"] = "Play the loot sound."
+L["OPTIONS_ENABLE_PICK_POCKET_SOUND"] = "Enable Pick Pocket Sound"
+L["OPTIONS_MINIMUM_QUALITY"] = "Minimum Quality"
+
+-- Loot Toasts
+L["OPTIONS_ENABLE_LOOT_TOASTS"] = "Enable Loot Toasts"
+-- The threshold bypasses, then the money row, in the order the panel lists them.
+L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"] = "Always Show Bind on Pickup Items"
+L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"] = "Always Show Quest Items"
+L["OPTIONS_ALWAYS_SHOW_RECIPES"] = "Always Show Recipes"
+L["OPTIONS_ALWAYS_SHOW_MOUNTS"] = "Always Show Mounts"
+L["OPTIONS_ALWAYS_SHOW_PETS"] = "Always Show Pets"
+L["OPTIONS_ALWAYS_SHOW_KEYS"] = "Always Show Keys"
+L["OPTIONS_ALWAYS_SHOW_BAGS"] = "Always Show Bags"
+L["OPTIONS_ALWAYS_SHOW_CONTAINERS"] = "Always Show Containers"
+L["OPTIONS_ALWAYS_SHOW_MONEY"] = "Always Show Money"
+L["OPTIONS_LOOT_TOAST_MAX_ITEMS"] = "Maximum Items to Display"
+L["OPTIONS_UNLIMITED"] = "Unlimited"
+L["OPTIONS_LOOT_TOAST_DURATION"] = "Seconds on Screen"
+L["OPTIONS_LOOT_TOAST_GROWTH"] = "Grow Direction"
+L["OPTIONS_GROW_UP"] = "Grow Up"
+L["OPTIONS_GROW_DOWN"] = "Grow Down"
+L["OPTIONS_LOOT_TOAST_ALIGN"] = "Align Items"
+L["OPTIONS_ALIGN_LEFT"] = "Left"
+L["OPTIONS_ALIGN_RIGHT"] = "Right"
+L["OPTIONS_LOOT_TOAST_FONT"] = "Font"
+L["OPTIONS_FONT_DEFAULT"] = "Default"
+L["OPTIONS_LOOT_TOAST_FONT_SIZE"] = "Font Size"
+L["OPTIONS_LOOT_TOAST_OUTLINE"] = "Font Outline"
+L["OPTIONS_FONT_OUTLINE_NONE"] = "None"
+L["OPTIONS_FONT_OUTLINE_OUTLINE"] = "Outline"
+L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"] = "Thick Outline"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME"] = "Monochrome"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"] = "Monochrome Outline"
+L["OPTIONS_TOASTS_UNLOCK"] = "Unlock Position"
+L["OPTIONS_TOASTS_LOCK"] = "Lock Position"
+L["OPTIONS_TOASTS_RESET"] = "Reset Position"
+L["OPTIONS_TOASTS_CLICK_DRAG"] = "Click + Drag to Position"
+L["OPTIONS_TOASTS_RIGHT_CLICK_LOCK"] = "Right-Click to Lock"
+L["OPTIONS_TOASTS_DISABLE_BUTTON"] = "Disable Loot Toasts"
+L["OPTIONS_TOASTS_EXAMPLE_ITEM"] = "Example Item"
+
+-- Commands
 L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
-L["OPTIONS_CMD_OS"] = "/os"
-L["OPTIONS_CMD_OS_DESCRIPTION"] = "Opens the Open Sesame options interface."
+L["OPTIONS_COMMAND"] = "/os"
+L["OPTIONS_COMMAND_DESCRIPTION"] = "Opens the Options Interface for this add-on."
+
+-- Ignore List
+L["OPTIONS_IGNORE_LIST_DESCRIPTION"] =
+	"Items on this list are left alone: Speedy Loot leaves them in the loot window, and Auto-Opening never opens them. The list is shared by all of your characters."
+L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"] = "Enable Ignore List Notifications"
+L["OPTIONS_IGNORE_LIST_ADD"] = "Add Item"
+L["OPTIONS_IGNORE_LIST_ADD_HINT"] = "Drag an item here, or paste an item link or item ID."
+L["OPTIONS_IGNORE_LIST_REMOVE"] = "Remove this item from the Ignore List."
+L["OPTIONS_IGNORE_LIST_RESTORE"] = "Restore Defaults"
+L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"] = "Restore the default Ignore List? Items you added will be removed."
+L["OPTIONS_IGNORE_REASON_RAID"] =
+	"Dropped by a raid boss. An unopened container can still be traded or sold, often for more than what is inside."
+L["OPTIONS_IGNORE_REASON_QUEST"] =
+	"May contain a unique quest item. Opening it may fail with an error if you already have one."
+L["OPTIONS_IGNORE_REASON_RECIPE"] =
+	"May contain a Bind on Pickup recipe. An unopened container can still be traded or sold."
+L["OPTIONS_IGNORE_REASON_GEAR"] =
+	"May contain a Bind on Pickup weapon or piece of armor. An unopened container can still be traded or sold."
+L["OPTIONS_IGNORE_REASON_HOLIDAY"] =
+	"May contain a Bind on Pickup holiday item. An unopened container can still be traded or sold."
+L["OPTIONS_IGNORE_REASON_ITEM"] =
+	"May contain a Bind on Pickup item. An unopened container can still be traded or sold."
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Feedback & Support"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/esES.lua
+++ b/Locales/esES.lua
@@ -13,33 +13,50 @@ L["STATUS_DISABLED"] = "Desactivado"
 L["STATUS_PAUSED"] = "En pausa"
 
 --------------------------------------------------------------------------------
+-- Panel Tabs
+--------------------------------------------------------------------------------
+
+L["TAB_NOTIFICATIONS"] = "Notificaciones"
+L["TAB_LOCKBOXES"] = "Cajas cerradas"
+L["TAB_IGNORE_LIST"] = "Lista de ignorados"
+
+--------------------------------------------------------------------------------
 -- Chat Messages
 --------------------------------------------------------------------------------
 
 -- System
-L["AUTO_LOOT_ENABLED"] = "El Despojo automático ha sido activado. Open Sesame lo necesita para funcionar."
+L["AUTO_LOOT_ENABLED"] = "Se ha activado el saqueo automático. Open Sesame lo necesita para funcionar."
+L["CHAT_OPTIONS_IN_COMBAT"] = "Por precaución, la Interfaz de Opciones no puede abrirse durante el combate."
 L["CHAT_LOADED"] =
-	"Versión %s. La configuración (incluida la opción para desactivar este mensaje) se puede encontrar en Opciones > AddOns > Open Sesame. ¿Te gusta el addon? ¡Cuéntaselo a un amigo! (="
+	"Versión %s. Los ajustes (incluida la opción de desactivar este mensaje) están en Opciones > AddOns > Open Sesame. ¿Te gusta el add-on? ¡Cuéntaselo a un amigo! (="
 
 -- Auto-Opening
-L["PAUSED_BAG_SLOTS"] = "La apertura automática está en pausa hasta tener al menos %d espacios libres en las bolsas."
+L["PAUSED_BAG_SLOTS"] =
+	"La apertura automática está en pausa hasta que tengas al menos %d espacios libres en la bolsa."
 L["RESUMED"] = "La apertura automática se ha reanudado."
 L["INVENTORY_FULL"] = "¡El inventario está lleno!"
-L["ITEM_WILL_AUTO_OPEN"] = "%s se abrirá automáticamente cuando se desbloquee."
-L["ITEM_OPEN_MANUALLY"] =
-	"%s debe abrirse manualmente. Puede contener un objeto único, ligado al recoger o temporal, o fue obtenido de un jefe de banda."
+L["ITEM_WILL_AUTO_OPEN"] = "%s se abrirá automáticamente en cuanto esté desbloqueado."
+L["ITEM_IGNORED"] = "%s está en tu lista de ignorados, así que la apertura automática no lo ha tocado."
+L["ITEM_OPEN_MANUALLY"] = "%s se ha dejado en la ventana de botín para que lo abras tú."
 
 --------------------------------------------------------------------------------
 -- Features
 --------------------------------------------------------------------------------
 
 L["AUTO_OPENING"] = "Apertura automática"
-L["AUTO_OPENING_DESC"] =
-	"Abre automáticamente almejas y contenedores desbloqueados cuando tienes al menos %d espacios libres en las bolsas."
-L["SPEEDY_LOOT"] = "Despojo rápido"
-L["SPEEDY_LOOT_DESC"] = "Oculta la ventana de botín para un despojo casi instantáneo."
+L["AUTO_OPENING_DESCRIPTION"] =
+	"Abre automáticamente almejas y contenedores desbloqueados cuando tienes al menos %d espacios libres en la bolsa."
+L["SPEEDY_LOOT"] = "Saqueo rápido"
+L["SPEEDY_LOOT_DESCRIPTION"] = "Oculta la ventana de botín para saquear casi al instante."
+L["NOTIFICATIONS_DESCRIPTION"] =
+	"El saqueo rápido oculta la ventana de botín, así que así es como Open Sesame te dice lo que acabas de recoger."
+L["LOCKBOXES_DESCRIPTION"] =
+	"Los contenedores cerrados necesitan la habilidad Abrir cerraduras de un pícaro para poder abrirse. Estas opciones muestran lo que requiere cada caja y te avisan cuando hay una esperando."
 L["LOOT_SOUNDS"] = "Sonido de botín"
-L["LOOT_SOUNDS_DESC"] = "Reproduce un sonido especial al obtener un objeto de calidad Poco común o superior."
+L["LOOT_SOUNDS_DESCRIPTION"] = "Reproduce un sonido según los ajustes de calidad que elijas."
+L["LOOT_TOASTS"] = "Avisos de botín"
+L["LOOT_TOASTS_DESCRIPTION"] =
+	"Muestra un aviso breve en pantalla de los objetos que saqueas, ya que el saqueo rápido oculta la ventana de botín. Sacar el botín del chat deja la ventana libre para conversar y para los mensajes que importan."
 
 --------------------------------------------------------------------------------
 -- Tooltip
@@ -48,27 +65,115 @@ L["LOOT_SOUNDS_DESC"] = "Reproduce un sonido especial al obtener un objeto de ca
 L["KEYBIND_LEFT_CLICK"] = "Clic izquierdo"
 L["KEYBIND_RIGHT_CLICK"] = "Clic derecho"
 L["KEYBIND_MIDDLE_CLICK"] = "Clic central"
-L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + Clic central"
+L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Mayús + Clic central"
 L["ACTION_TOGGLE"] = "Alternar"
 L["TOOLTIP_OPTIONS_TITLE"] = "Opciones de Open Sesame"
+L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"] = "Requiere Abrir cerraduras"
+L["TOOLTIP_YOUR_LOCKPICKING_LABEL"] = "Tu Abrir cerraduras"
+L["TOOLTIP_LOCKED_ITEMS"] = "Objetos cerrados"
 
 --------------------------------------------------------------------------------
 -- Options
 --------------------------------------------------------------------------------
 
-L["OPTIONS_INTRO"] =
-	"Open Sesame abre automáticamente almejas, cajas con cerradura y contenedores desbloqueados en tus bolsas. El Despojo rápido integrado oculta la ventana de botín para un despojo casi instantáneo. Menos clics, más tiempo de juego."
+-- General Panel
+L["OPTIONS_DESCRIPTION"] =
+	"Abre automáticamente almejas, cajas cerradas y contenedores desbloqueados de tus bolsas, sin hacer clic. El saqueo rápido integrado oculta la ventana de botín para un saqueo automático casi instantáneo. Menos clics, más juego."
 L["OPTIONS_ENABLE_WELCOME"] = "Activar mensaje de bienvenida"
 L["OPTIONS_ENABLE_MINIMAP"] = "Activar botón del minimapa"
-L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Activar notificaciones de cajas con cerradura"
+
+-- Auto-Opening
 L["OPTIONS_ENABLE_AUTO_OPENING"] = "Activar apertura automática"
-L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "Activar despojo rápido"
+L["OPTIONS_AUTO_OPENING_WHERE"] = "Dónde"
+L["OPTIONS_ANYWHERE"] = "En cualquier lugar"
+L["OPTIONS_OUTSIDE_INSTANCES"] = "Fuera de mazmorras"
+L["OPTIONS_AUTO_OPENING_GROUP"] = "Grupo"
+L["OPTIONS_SOLO_OR_GROUPED"] = "Solo o en grupo"
+L["OPTIONS_SOLO_ONLY"] = "Solo en solitario"
+
+-- Speedy Loot
+L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "Activar saqueo rápido"
+
+-- Lockboxes
+L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"] = "Activar descripciones de cajas cerradas"
+L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Activar notificaciones de cajas cerradas"
+L["OPTIONS_SHOW_FOR"] = "Mostrar para"
+L["OPTIONS_FOR_ROGUES"] = "Para pícaros"
+L["OPTIONS_FOR_ALL_CHARACTERS"] = "Para todos los personajes"
+
+-- Notifications
 L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "Activar sonido de botín"
-L["OPTIONS_LOOT_SOUND_THRESHOLD"] = "Calidad mínima para el sonido de botín"
 L["OPTIONS_TEST_LOOT_SOUND"] = "Reproducir el sonido de botín."
-L["OPTIONS_COMMANDS_HEADER"] = "/Comandos"
-L["OPTIONS_CMD_OS"] = "/os"
-L["OPTIONS_CMD_OS_DESCRIPTION"] = "Abre la interfaz de opciones de Open Sesame."
+L["OPTIONS_ENABLE_PICK_POCKET_SOUND"] = "Activar sonido de Robar bolsillos"
+L["OPTIONS_MINIMUM_QUALITY"] = "Calidad mínima"
+
+-- Loot Toasts
+L["OPTIONS_ENABLE_LOOT_TOASTS"] = "Activar avisos de botín"
+-- The threshold bypasses, then the money row, in the order the panel lists them.
+L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"] = "Mostrar siempre objetos que se ligan al recoger"
+L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"] = "Mostrar siempre objetos de misión"
+L["OPTIONS_ALWAYS_SHOW_RECIPES"] = "Mostrar siempre recetas"
+L["OPTIONS_ALWAYS_SHOW_MOUNTS"] = "Mostrar siempre monturas"
+L["OPTIONS_ALWAYS_SHOW_PETS"] = "Mostrar siempre mascotas"
+L["OPTIONS_ALWAYS_SHOW_KEYS"] = "Mostrar siempre llaves"
+L["OPTIONS_ALWAYS_SHOW_BAGS"] = "Mostrar siempre bolsas"
+L["OPTIONS_ALWAYS_SHOW_CONTAINERS"] = "Mostrar siempre contenedores"
+L["OPTIONS_ALWAYS_SHOW_MONEY"] = "Mostrar siempre dinero"
+L["OPTIONS_LOOT_TOAST_MAX_ITEMS"] = "Máximo de objetos a mostrar"
+L["OPTIONS_UNLIMITED"] = "Ilimitado"
+L["OPTIONS_LOOT_TOAST_DURATION"] = "Segundos en pantalla"
+L["OPTIONS_LOOT_TOAST_GROWTH"] = "Dirección de crecimiento"
+L["OPTIONS_GROW_UP"] = "Hacia arriba"
+L["OPTIONS_GROW_DOWN"] = "Hacia abajo"
+L["OPTIONS_LOOT_TOAST_ALIGN"] = "Alinear objetos"
+L["OPTIONS_ALIGN_LEFT"] = "Izquierda"
+L["OPTIONS_ALIGN_RIGHT"] = "Derecha"
+L["OPTIONS_LOOT_TOAST_FONT"] = "Fuente"
+L["OPTIONS_FONT_DEFAULT"] = "Predeterminada"
+L["OPTIONS_LOOT_TOAST_FONT_SIZE"] = "Tamaño de fuente"
+L["OPTIONS_LOOT_TOAST_OUTLINE"] = "Contorno de fuente"
+L["OPTIONS_FONT_OUTLINE_NONE"] = "Ninguno"
+L["OPTIONS_FONT_OUTLINE_OUTLINE"] = "Contorno"
+L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"] = "Contorno grueso"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME"] = "Monocromo"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"] = "Contorno monocromo"
+L["OPTIONS_TOASTS_UNLOCK"] = "Desbloquear posición"
+L["OPTIONS_TOASTS_LOCK"] = "Bloquear posición"
+L["OPTIONS_TOASTS_RESET"] = "Restablecer posición"
+L["OPTIONS_TOASTS_CLICK_DRAG"] = "Clic + Arrastrar para colocar"
+L["OPTIONS_TOASTS_RIGHT_CLICK_LOCK"] = "Clic derecho para bloquear"
+L["OPTIONS_TOASTS_DISABLE_BUTTON"] = "Desactivar avisos de botín"
+L["OPTIONS_TOASTS_EXAMPLE_ITEM"] = "Objeto de ejemplo"
+
+-- Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
+L["OPTIONS_COMMAND"] = "/os"
+L["OPTIONS_COMMAND_DESCRIPTION"] = "Abre la Interfaz de Opciones de este add-on."
+
+-- Ignore List
+L["OPTIONS_IGNORE_LIST_DESCRIPTION"] =
+	"Los objetos de esta lista se dejan intactos: el saqueo rápido los deja en la ventana de botín y la apertura automática nunca los abre. La lista es común a todos tus personajes."
+L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"] = "Activar notificaciones de la lista de ignorados"
+L["OPTIONS_IGNORE_LIST_ADD"] = "Añadir objeto"
+L["OPTIONS_IGNORE_LIST_ADD_HINT"] = "Arrastra un objeto aquí o pega un enlace de objeto o un ID de objeto."
+L["OPTIONS_IGNORE_LIST_REMOVE"] = "Quitar este objeto de la lista de ignorados."
+L["OPTIONS_IGNORE_LIST_RESTORE"] = "Restaurar valores predeterminados"
+L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"] =
+	"¿Restaurar la lista de ignorados predeterminada? Se quitarán los objetos que hayas añadido."
+L["OPTIONS_IGNORE_REASON_RAID"] =
+	"Lo suelta un jefe de banda. Un contenedor sin abrir todavía se puede comerciar o vender, a menudo por más de lo que contiene."
+L["OPTIONS_IGNORE_REASON_QUEST"] =
+	"Puede contener un objeto de misión único. Abrirlo puede fallar con un error si ya tienes uno."
+L["OPTIONS_IGNORE_REASON_RECIPE"] =
+	"Puede contener una receta que se liga al recoger. Un contenedor sin abrir todavía se puede comerciar o vender."
+L["OPTIONS_IGNORE_REASON_GEAR"] =
+	"Puede contener un arma o una pieza de armadura que se liga al recoger. Un contenedor sin abrir todavía se puede comerciar o vender."
+L["OPTIONS_IGNORE_REASON_HOLIDAY"] =
+	"Puede contener un objeto de evento que se liga al recoger. Un contenedor sin abrir todavía se puede comerciar o vender."
+L["OPTIONS_IGNORE_REASON_ITEM"] =
+	"Puede contener un objeto que se liga al recoger. Un contenedor sin abrir todavía se puede comerciar o vender."
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Comentarios y soporte"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/esMX.lua
+++ b/Locales/esMX.lua
@@ -13,33 +13,50 @@ L["STATUS_DISABLED"] = "Desactivado"
 L["STATUS_PAUSED"] = "En pausa"
 
 --------------------------------------------------------------------------------
+-- Panel Tabs
+--------------------------------------------------------------------------------
+
+L["TAB_NOTIFICATIONS"] = "Notificaciones"
+L["TAB_LOCKBOXES"] = "Cajas cerradas"
+L["TAB_IGNORE_LIST"] = "Lista de ignorados"
+
+--------------------------------------------------------------------------------
 -- Chat Messages
 --------------------------------------------------------------------------------
 
 -- System
-L["AUTO_LOOT_ENABLED"] = "El Despojo automático ha sido activado. Open Sesame lo necesita para funcionar."
+L["AUTO_LOOT_ENABLED"] = "Se ha activado el saqueo automático. Open Sesame lo necesita para funcionar."
+L["CHAT_OPTIONS_IN_COMBAT"] = "Por precaución, la Interfaz de Opciones no puede abrirse durante el combate."
 L["CHAT_LOADED"] =
-	"Versión %s. La configuración (incluida la opción para desactivar este mensaje) se puede encontrar en Opciones > AddOns > Open Sesame. ¿Te gusta el addon? ¡Cuéntaselo a un amigo! (="
+	"Versión %s. Los ajustes (incluida la opción de desactivar este mensaje) están en Opciones > AddOns > Open Sesame. ¿Te gusta el add-on? ¡Cuéntaselo a un amigo! (="
 
 -- Auto-Opening
-L["PAUSED_BAG_SLOTS"] = "La apertura automática está en pausa hasta tener al menos %d espacios libres en las bolsas."
+L["PAUSED_BAG_SLOTS"] =
+	"La apertura automática está en pausa hasta que tengas al menos %d espacios libres en la bolsa."
 L["RESUMED"] = "La apertura automática se ha reanudado."
 L["INVENTORY_FULL"] = "¡El inventario está lleno!"
-L["ITEM_WILL_AUTO_OPEN"] = "%s se abrirá automáticamente cuando se desbloquee."
-L["ITEM_OPEN_MANUALLY"] =
-	"%s debe abrirse manualmente. Puede contener un objeto único, ligado al recoger o temporal, o fue obtenido de un jefe de banda."
+L["ITEM_WILL_AUTO_OPEN"] = "%s se abrirá automáticamente en cuanto esté desbloqueado."
+L["ITEM_IGNORED"] = "%s está en tu lista de ignorados, así que la apertura automática no lo ha tocado."
+L["ITEM_OPEN_MANUALLY"] = "%s se ha dejado en la ventana de botín para que lo abras tú."
 
 --------------------------------------------------------------------------------
 -- Features
 --------------------------------------------------------------------------------
 
 L["AUTO_OPENING"] = "Apertura automática"
-L["AUTO_OPENING_DESC"] =
-	"Abre automáticamente almejas y contenedores desbloqueados cuando tienes al menos %d espacios libres en las bolsas."
-L["SPEEDY_LOOT"] = "Despojo rápido"
-L["SPEEDY_LOOT_DESC"] = "Oculta la ventana de botín para un despojo casi instantáneo."
+L["AUTO_OPENING_DESCRIPTION"] =
+	"Abre automáticamente almejas y contenedores desbloqueados cuando tienes al menos %d espacios libres en la bolsa."
+L["SPEEDY_LOOT"] = "Saqueo rápido"
+L["SPEEDY_LOOT_DESCRIPTION"] = "Oculta la ventana de botín para saquear casi al instante."
+L["NOTIFICATIONS_DESCRIPTION"] =
+	"El saqueo rápido oculta la ventana de botín, así que así es como Open Sesame te dice lo que acabas de recoger."
+L["LOCKBOXES_DESCRIPTION"] =
+	"Los contenedores cerrados necesitan la habilidad Abrir cerraduras de un pícaro para poder abrirse. Estas opciones muestran lo que requiere cada caja y te avisan cuando hay una esperando."
 L["LOOT_SOUNDS"] = "Sonido de botín"
-L["LOOT_SOUNDS_DESC"] = "Reproduce un sonido especial al obtener un objeto de calidad Poco común o superior."
+L["LOOT_SOUNDS_DESCRIPTION"] = "Reproduce un sonido según los ajustes de calidad que elijas."
+L["LOOT_TOASTS"] = "Avisos de botín"
+L["LOOT_TOASTS_DESCRIPTION"] =
+	"Muestra un aviso breve en pantalla de los objetos que saqueas, ya que el saqueo rápido oculta la ventana de botín. Sacar el botín del chat deja la ventana libre para conversar y para los mensajes que importan."
 
 --------------------------------------------------------------------------------
 -- Tooltip
@@ -48,27 +65,115 @@ L["LOOT_SOUNDS_DESC"] = "Reproduce un sonido especial al obtener un objeto de ca
 L["KEYBIND_LEFT_CLICK"] = "Clic izquierdo"
 L["KEYBIND_RIGHT_CLICK"] = "Clic derecho"
 L["KEYBIND_MIDDLE_CLICK"] = "Clic central"
-L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + Clic central"
+L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Mayús + Clic central"
 L["ACTION_TOGGLE"] = "Alternar"
 L["TOOLTIP_OPTIONS_TITLE"] = "Opciones de Open Sesame"
+L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"] = "Requiere Abrir cerraduras"
+L["TOOLTIP_YOUR_LOCKPICKING_LABEL"] = "Tu Abrir cerraduras"
+L["TOOLTIP_LOCKED_ITEMS"] = "Objetos cerrados"
 
 --------------------------------------------------------------------------------
 -- Options
 --------------------------------------------------------------------------------
 
-L["OPTIONS_INTRO"] =
-	"Open Sesame abre automáticamente almejas, cajas con cerradura y contenedores desbloqueados en tus bolsas. El Despojo rápido integrado oculta la ventana de botín para un despojo casi instantáneo. Menos clics, más tiempo de juego."
+-- General Panel
+L["OPTIONS_DESCRIPTION"] =
+	"Abre automáticamente almejas, cajas cerradas y contenedores desbloqueados de tus bolsas, sin hacer clic. El saqueo rápido integrado oculta la ventana de botín para un saqueo automático casi instantáneo. Menos clics, más juego."
 L["OPTIONS_ENABLE_WELCOME"] = "Activar mensaje de bienvenida"
 L["OPTIONS_ENABLE_MINIMAP"] = "Activar botón del minimapa"
-L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Activar notificaciones de cajas con cerradura"
+
+-- Auto-Opening
 L["OPTIONS_ENABLE_AUTO_OPENING"] = "Activar apertura automática"
-L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "Activar despojo rápido"
+L["OPTIONS_AUTO_OPENING_WHERE"] = "Dónde"
+L["OPTIONS_ANYWHERE"] = "En cualquier lugar"
+L["OPTIONS_OUTSIDE_INSTANCES"] = "Fuera de mazmorras"
+L["OPTIONS_AUTO_OPENING_GROUP"] = "Grupo"
+L["OPTIONS_SOLO_OR_GROUPED"] = "Solo o en grupo"
+L["OPTIONS_SOLO_ONLY"] = "Solo en solitario"
+
+-- Speedy Loot
+L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "Activar saqueo rápido"
+
+-- Lockboxes
+L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"] = "Activar descripciones de cajas cerradas"
+L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Activar notificaciones de cajas cerradas"
+L["OPTIONS_SHOW_FOR"] = "Mostrar para"
+L["OPTIONS_FOR_ROGUES"] = "Para pícaros"
+L["OPTIONS_FOR_ALL_CHARACTERS"] = "Para todos los personajes"
+
+-- Notifications
 L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "Activar sonido de botín"
-L["OPTIONS_LOOT_SOUND_THRESHOLD"] = "Calidad mínima para el sonido de botín"
 L["OPTIONS_TEST_LOOT_SOUND"] = "Reproducir el sonido de botín."
-L["OPTIONS_COMMANDS_HEADER"] = "/Comandos"
-L["OPTIONS_CMD_OS"] = "/os"
-L["OPTIONS_CMD_OS_DESCRIPTION"] = "Abre la interfaz de opciones de Open Sesame."
+L["OPTIONS_ENABLE_PICK_POCKET_SOUND"] = "Activar sonido de Robar bolsillos"
+L["OPTIONS_MINIMUM_QUALITY"] = "Calidad mínima"
+
+-- Loot Toasts
+L["OPTIONS_ENABLE_LOOT_TOASTS"] = "Activar avisos de botín"
+-- The threshold bypasses, then the money row, in the order the panel lists them.
+L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"] = "Mostrar siempre objetos que se ligan al recoger"
+L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"] = "Mostrar siempre objetos de misión"
+L["OPTIONS_ALWAYS_SHOW_RECIPES"] = "Mostrar siempre recetas"
+L["OPTIONS_ALWAYS_SHOW_MOUNTS"] = "Mostrar siempre monturas"
+L["OPTIONS_ALWAYS_SHOW_PETS"] = "Mostrar siempre mascotas"
+L["OPTIONS_ALWAYS_SHOW_KEYS"] = "Mostrar siempre llaves"
+L["OPTIONS_ALWAYS_SHOW_BAGS"] = "Mostrar siempre bolsas"
+L["OPTIONS_ALWAYS_SHOW_CONTAINERS"] = "Mostrar siempre contenedores"
+L["OPTIONS_ALWAYS_SHOW_MONEY"] = "Mostrar siempre dinero"
+L["OPTIONS_LOOT_TOAST_MAX_ITEMS"] = "Máximo de objetos a mostrar"
+L["OPTIONS_UNLIMITED"] = "Ilimitado"
+L["OPTIONS_LOOT_TOAST_DURATION"] = "Segundos en pantalla"
+L["OPTIONS_LOOT_TOAST_GROWTH"] = "Dirección de crecimiento"
+L["OPTIONS_GROW_UP"] = "Hacia arriba"
+L["OPTIONS_GROW_DOWN"] = "Hacia abajo"
+L["OPTIONS_LOOT_TOAST_ALIGN"] = "Alinear objetos"
+L["OPTIONS_ALIGN_LEFT"] = "Izquierda"
+L["OPTIONS_ALIGN_RIGHT"] = "Derecha"
+L["OPTIONS_LOOT_TOAST_FONT"] = "Fuente"
+L["OPTIONS_FONT_DEFAULT"] = "Predeterminada"
+L["OPTIONS_LOOT_TOAST_FONT_SIZE"] = "Tamaño de fuente"
+L["OPTIONS_LOOT_TOAST_OUTLINE"] = "Contorno de fuente"
+L["OPTIONS_FONT_OUTLINE_NONE"] = "Ninguno"
+L["OPTIONS_FONT_OUTLINE_OUTLINE"] = "Contorno"
+L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"] = "Contorno grueso"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME"] = "Monocromo"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"] = "Contorno monocromo"
+L["OPTIONS_TOASTS_UNLOCK"] = "Desbloquear posición"
+L["OPTIONS_TOASTS_LOCK"] = "Bloquear posición"
+L["OPTIONS_TOASTS_RESET"] = "Restablecer posición"
+L["OPTIONS_TOASTS_CLICK_DRAG"] = "Clic + Arrastrar para colocar"
+L["OPTIONS_TOASTS_RIGHT_CLICK_LOCK"] = "Clic derecho para bloquear"
+L["OPTIONS_TOASTS_DISABLE_BUTTON"] = "Desactivar avisos de botín"
+L["OPTIONS_TOASTS_EXAMPLE_ITEM"] = "Objeto de ejemplo"
+
+-- Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
+L["OPTIONS_COMMAND"] = "/os"
+L["OPTIONS_COMMAND_DESCRIPTION"] = "Abre la Interfaz de Opciones de este add-on."
+
+-- Ignore List
+L["OPTIONS_IGNORE_LIST_DESCRIPTION"] =
+	"Los objetos de esta lista se dejan intactos: el saqueo rápido los deja en la ventana de botín y la apertura automática nunca los abre. La lista es común a todos tus personajes."
+L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"] = "Activar notificaciones de la lista de ignorados"
+L["OPTIONS_IGNORE_LIST_ADD"] = "Añadir objeto"
+L["OPTIONS_IGNORE_LIST_ADD_HINT"] = "Arrastra un objeto aquí o pega un enlace de objeto o un ID de objeto."
+L["OPTIONS_IGNORE_LIST_REMOVE"] = "Quitar este objeto de la lista de ignorados."
+L["OPTIONS_IGNORE_LIST_RESTORE"] = "Restaurar valores predeterminados"
+L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"] =
+	"¿Restaurar la lista de ignorados predeterminada? Se quitarán los objetos que hayas añadido."
+L["OPTIONS_IGNORE_REASON_RAID"] =
+	"Lo suelta un jefe de banda. Un contenedor sin abrir todavía se puede comerciar o vender, a menudo por más de lo que contiene."
+L["OPTIONS_IGNORE_REASON_QUEST"] =
+	"Puede contener un objeto de misión único. Abrirlo puede fallar con un error si ya tienes uno."
+L["OPTIONS_IGNORE_REASON_RECIPE"] =
+	"Puede contener una receta que se liga al recoger. Un contenedor sin abrir todavía se puede comerciar o vender."
+L["OPTIONS_IGNORE_REASON_GEAR"] =
+	"Puede contener un arma o una pieza de armadura que se liga al recoger. Un contenedor sin abrir todavía se puede comerciar o vender."
+L["OPTIONS_IGNORE_REASON_HOLIDAY"] =
+	"Puede contener un objeto de evento que se liga al recoger. Un contenedor sin abrir todavía se puede comerciar o vender."
+L["OPTIONS_IGNORE_REASON_ITEM"] =
+	"Puede contener un objeto que se liga al recoger. Un contenedor sin abrir todavía se puede comerciar o vender."
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Comentarios y soporte"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -13,34 +13,50 @@ L["STATUS_DISABLED"] = "Désactivé"
 L["STATUS_PAUSED"] = "En pause"
 
 --------------------------------------------------------------------------------
+-- Panel Tabs
+--------------------------------------------------------------------------------
+
+L["TAB_NOTIFICATIONS"] = "Notifications"
+L["TAB_LOCKBOXES"] = "Coffres verrouillés"
+L["TAB_IGNORE_LIST"] = "Liste d'exclusion"
+
+--------------------------------------------------------------------------------
 -- Chat Messages
 --------------------------------------------------------------------------------
 
 -- System
-L["AUTO_LOOT_ENABLED"] = "La Fouille automatique a été activée. Open Sesame en a besoin pour fonctionner."
+L["AUTO_LOOT_ENABLED"] = "Le butin automatique a été activé. Open Sesame en a besoin pour fonctionner."
+L["CHAT_OPTIONS_IN_COMBAT"] = "Par précaution, l'Interface d'Options ne peut pas être ouverte en combat."
 L["CHAT_LOADED"] =
-	"Version %s. Les paramètres (y compris l'option pour désactiver ce message) se trouvent dans Options > AddOns > Open Sesame. Vous aimez l'addon ? Parlez-en à un ami ! (="
+	"Version %s. Les réglages (dont l'option pour désactiver ce message) se trouvent dans Options > AddOns > Open Sesame. L'add-on vous plaît ? Parlez-en à un ami ! (="
 
 -- Auto-Opening
 L["PAUSED_BAG_SLOTS"] =
-	"L'ouverture automatique est en pause jusqu'à ce que vous ayez au moins %d emplacements de sac libres."
+	"L'ouverture automatique est en pause tant que vous n'avez pas au moins %d emplacements de sac libres."
 L["RESUMED"] = "L'ouverture automatique a repris."
 L["INVENTORY_FULL"] = "L'inventaire est plein !"
-L["ITEM_WILL_AUTO_OPEN"] = "%s sera automatiquement ouvert une fois déverrouillé."
-L["ITEM_OPEN_MANUALLY"] =
-	"%s doit être ouvert manuellement. Il peut contenir un objet unique, lié quand ramassé ou temporaire, ou a été lâché par un boss de raid."
+L["ITEM_WILL_AUTO_OPEN"] = "%s sera ouvert automatiquement dès qu'il sera déverrouillé."
+L["ITEM_IGNORED"] = "%s est dans votre liste d'exclusion, l'ouverture automatique l'a donc laissé tranquille."
+L["ITEM_OPEN_MANUALLY"] = "%s a été laissé dans la fenêtre de butin pour que vous l'ouvriez vous-même."
 
 --------------------------------------------------------------------------------
 -- Features
 --------------------------------------------------------------------------------
 
 L["AUTO_OPENING"] = "Ouverture automatique"
-L["AUTO_OPENING_DESC"] =
+L["AUTO_OPENING_DESCRIPTION"] =
 	"Ouvre automatiquement les palourdes et les conteneurs déverrouillés quand vous avez au moins %d emplacements de sac libres."
 L["SPEEDY_LOOT"] = "Butin rapide"
-L["SPEEDY_LOOT_DESC"] = "Masque la fenêtre de butin pour un ramassage quasi instantané."
+L["SPEEDY_LOOT_DESCRIPTION"] = "Masque la fenêtre de butin pour un ramassage quasi instantané."
+L["NOTIFICATIONS_DESCRIPTION"] =
+	"Le butin rapide masque la fenêtre de butin, c'est donc ainsi qu'Open Sesame vous dit ce que vous venez de ramasser."
+L["LOCKBOXES_DESCRIPTION"] =
+	"Les conteneurs verrouillés nécessitent la compétence Crochetage d'un voleur avant de s'ouvrir. Ces options indiquent ce que chaque coffre exige et vous préviennent quand l'un d'eux attend."
 L["LOOT_SOUNDS"] = "Son de butin"
-L["LOOT_SOUNDS_DESC"] = "Joue un son distinct quand vous ramassez un objet de qualité Inhabituelle ou supérieure."
+L["LOOT_SOUNDS_DESCRIPTION"] = "Joue un son selon les réglages de qualité de votre choix."
+L["LOOT_TOASTS"] = "Notifications de butin"
+L["LOOT_TOASTS_DESCRIPTION"] =
+	"Affiche un bref message à l'écran pour les objets que vous ramassez, puisque le butin rapide masque la fenêtre de butin. Sortir le butin du chat libère la fenêtre pour les conversations et les messages qui comptent."
 
 --------------------------------------------------------------------------------
 -- Tooltip
@@ -48,29 +64,117 @@ L["LOOT_SOUNDS_DESC"] = "Joue un son distinct quand vous ramassez un objet de qu
 
 L["KEYBIND_LEFT_CLICK"] = "Clic gauche"
 L["KEYBIND_RIGHT_CLICK"] = "Clic droit"
-L["KEYBIND_MIDDLE_CLICK"] = "Clic molette"
-L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + Clic molette"
+L["KEYBIND_MIDDLE_CLICK"] = "Clic milieu"
+L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Maj + Clic milieu"
 L["ACTION_TOGGLE"] = "Basculer"
 L["TOOLTIP_OPTIONS_TITLE"] = "Options d'Open Sesame"
+L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"] = "Crochetage requis"
+L["TOOLTIP_YOUR_LOCKPICKING_LABEL"] = "Votre Crochetage"
+L["TOOLTIP_LOCKED_ITEMS"] = "Objets verrouillés"
 
 --------------------------------------------------------------------------------
 -- Options
 --------------------------------------------------------------------------------
 
-L["OPTIONS_INTRO"] =
-	"Open Sesame ouvre automatiquement les palourdes, les coffres-forts et les conteneurs déverrouillés dans vos sacs. Le Butin rapide intégré masque la fenêtre de butin pour un ramassage quasi instantané. Moins de clics, plus de jeu."
+-- General Panel
+L["OPTIONS_DESCRIPTION"] =
+	"Ouvre automatiquement les palourdes, les coffres verrouillés et les conteneurs déverrouillés de vos sacs, sans aucun clic. Le butin rapide intégré masque la fenêtre de butin pour un ramassage automatique quasi instantané. Moins de clics, plus de jeu."
 L["OPTIONS_ENABLE_WELCOME"] = "Activer le message de bienvenue"
 L["OPTIONS_ENABLE_MINIMAP"] = "Activer le bouton de la mini-carte"
-L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Activer les notifications de coffres-forts"
+
+-- Auto-Opening
 L["OPTIONS_ENABLE_AUTO_OPENING"] = "Activer l'ouverture automatique"
+L["OPTIONS_AUTO_OPENING_WHERE"] = "Où"
+L["OPTIONS_ANYWHERE"] = "Partout"
+L["OPTIONS_OUTSIDE_INSTANCES"] = "Hors des instances"
+L["OPTIONS_AUTO_OPENING_GROUP"] = "Groupe"
+L["OPTIONS_SOLO_OR_GROUPED"] = "Seul ou en groupe"
+L["OPTIONS_SOLO_ONLY"] = "Seul uniquement"
+
+-- Speedy Loot
 L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "Activer le butin rapide"
+
+-- Lockboxes
+L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"] = "Activer les infobulles de coffres"
+L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Activer les notifications de coffres"
+L["OPTIONS_SHOW_FOR"] = "Afficher pour"
+L["OPTIONS_FOR_ROGUES"] = "Pour les voleurs"
+L["OPTIONS_FOR_ALL_CHARACTERS"] = "Pour tous les personnages"
+
+-- Notifications
 L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "Activer le son de butin"
-L["OPTIONS_LOOT_SOUND_THRESHOLD"] = "Qualité minimale pour le son de butin"
-L["OPTIONS_TEST_LOOT_SOUND"] = "Écouter le son de butin."
-L["OPTIONS_COMMANDS_HEADER"] = "/Commandes"
-L["OPTIONS_CMD_OS"] = "/os"
-L["OPTIONS_CMD_OS_DESCRIPTION"] = "Ouvre l'interface des options d'Open Sesame."
-L["OPTIONS_FEEDBACK"] = "Commentaires et support"
+L["OPTIONS_TEST_LOOT_SOUND"] = "Jouer le son de butin."
+L["OPTIONS_ENABLE_PICK_POCKET_SOUND"] = "Activer le son de Pickpocket"
+L["OPTIONS_MINIMUM_QUALITY"] = "Qualité minimale"
+
+-- Loot Toasts
+L["OPTIONS_ENABLE_LOOT_TOASTS"] = "Activer les notifications de butin"
+-- The threshold bypasses, then the money row, in the order the panel lists them.
+L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"] = "Toujours afficher les objets liés quand ramassés"
+L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"] = "Toujours afficher les objets de quête"
+L["OPTIONS_ALWAYS_SHOW_RECIPES"] = "Toujours afficher les recettes"
+L["OPTIONS_ALWAYS_SHOW_MOUNTS"] = "Toujours afficher les montures"
+L["OPTIONS_ALWAYS_SHOW_PETS"] = "Toujours afficher les mascottes"
+L["OPTIONS_ALWAYS_SHOW_KEYS"] = "Toujours afficher les clés"
+L["OPTIONS_ALWAYS_SHOW_BAGS"] = "Toujours afficher les sacs"
+L["OPTIONS_ALWAYS_SHOW_CONTAINERS"] = "Toujours afficher les conteneurs"
+L["OPTIONS_ALWAYS_SHOW_MONEY"] = "Toujours afficher l'argent"
+L["OPTIONS_LOOT_TOAST_MAX_ITEMS"] = "Nombre maximum d'objets affichés"
+L["OPTIONS_UNLIMITED"] = "Illimité"
+L["OPTIONS_LOOT_TOAST_DURATION"] = "Secondes à l'écran"
+L["OPTIONS_LOOT_TOAST_GROWTH"] = "Direction de croissance"
+L["OPTIONS_GROW_UP"] = "Vers le haut"
+L["OPTIONS_GROW_DOWN"] = "Vers le bas"
+L["OPTIONS_LOOT_TOAST_ALIGN"] = "Aligner les objets"
+L["OPTIONS_ALIGN_LEFT"] = "Gauche"
+L["OPTIONS_ALIGN_RIGHT"] = "Droite"
+L["OPTIONS_LOOT_TOAST_FONT"] = "Police"
+L["OPTIONS_FONT_DEFAULT"] = "Par défaut"
+L["OPTIONS_LOOT_TOAST_FONT_SIZE"] = "Taille de police"
+L["OPTIONS_LOOT_TOAST_OUTLINE"] = "Contour de police"
+L["OPTIONS_FONT_OUTLINE_NONE"] = "Aucun"
+L["OPTIONS_FONT_OUTLINE_OUTLINE"] = "Contour"
+L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"] = "Contour épais"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME"] = "Monochrome"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"] = "Contour monochrome"
+L["OPTIONS_TOASTS_UNLOCK"] = "Déverrouiller la position"
+L["OPTIONS_TOASTS_LOCK"] = "Verrouiller la position"
+L["OPTIONS_TOASTS_RESET"] = "Réinitialiser la position"
+L["OPTIONS_TOASTS_CLICK_DRAG"] = "Clic + Glisser pour positionner"
+L["OPTIONS_TOASTS_RIGHT_CLICK_LOCK"] = "Clic droit pour verrouiller"
+L["OPTIONS_TOASTS_DISABLE_BUTTON"] = "Désactiver les notifications de butin"
+L["OPTIONS_TOASTS_EXAMPLE_ITEM"] = "Objet d'exemple"
+
+-- Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
+L["OPTIONS_COMMAND"] = "/os"
+L["OPTIONS_COMMAND_DESCRIPTION"] = "Ouvre l'Interface d'Options de cet add-on."
+
+-- Ignore List
+L["OPTIONS_IGNORE_LIST_DESCRIPTION"] =
+	"Les objets de cette liste sont laissés tranquilles : le butin rapide les laisse dans la fenêtre de butin et l'ouverture automatique ne les ouvre jamais. La liste est partagée par tous vos personnages."
+L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"] = "Activer les notifications de la liste d'exclusion"
+L["OPTIONS_IGNORE_LIST_ADD"] = "Ajouter un objet"
+L["OPTIONS_IGNORE_LIST_ADD_HINT"] = "Glissez un objet ici, ou collez un lien d'objet ou un ID d'objet."
+L["OPTIONS_IGNORE_LIST_REMOVE"] = "Retirer cet objet de la liste d'exclusion."
+L["OPTIONS_IGNORE_LIST_RESTORE"] = "Restaurer les valeurs par défaut"
+L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"] =
+	"Restaurer la liste d'exclusion par défaut ? Les objets que vous avez ajoutés seront retirés."
+L["OPTIONS_IGNORE_REASON_RAID"] =
+	"Butin d'un boss de raid. Un conteneur non ouvert peut encore être échangé ou vendu, souvent pour plus que son contenu."
+L["OPTIONS_IGNORE_REASON_QUEST"] =
+	"Peut contenir un objet de quête unique. L'ouvrir peut échouer avec une erreur si vous en avez déjà un."
+L["OPTIONS_IGNORE_REASON_RECIPE"] =
+	"Peut contenir une recette liée quand ramassée. Un conteneur non ouvert peut encore être échangé ou vendu."
+L["OPTIONS_IGNORE_REASON_GEAR"] =
+	"Peut contenir une arme ou une pièce d'armure liée quand ramassée. Un conteneur non ouvert peut encore être échangé ou vendu."
+L["OPTIONS_IGNORE_REASON_HOLIDAY"] =
+	"Peut contenir un objet de fête lié quand ramassé. Un conteneur non ouvert peut encore être échangé ou vendu."
+L["OPTIONS_IGNORE_REASON_ITEM"] =
+	"Peut contenir un objet lié quand ramassé. Un conteneur non ouvert peut encore être échangé ou vendu."
+
+-- Feedback & Support
+L["OPTIONS_FEEDBACK"] = "Retours et assistance"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"
 L["OPTIONS_DISCORD"] = "Discord"

--- a/Locales/itIT.lua
+++ b/Locales/itIT.lua
@@ -8,38 +8,54 @@ end
 --------------------------------------------------------------------------------
 
 L["ADDON_TITLE"] = "Open Sesame"
-L["STATUS_ENABLED"] = "Attivato"
+L["STATUS_ENABLED"] = "Attivo"
 L["STATUS_DISABLED"] = "Disattivato"
 L["STATUS_PAUSED"] = "In pausa"
+
+--------------------------------------------------------------------------------
+-- Panel Tabs
+--------------------------------------------------------------------------------
+
+L["TAB_NOTIFICATIONS"] = "Notifiche"
+L["TAB_LOCKBOXES"] = "Scrigni chiusi"
+L["TAB_IGNORE_LIST"] = "Lista ignorati"
 
 --------------------------------------------------------------------------------
 -- Chat Messages
 --------------------------------------------------------------------------------
 
 -- System
-L["AUTO_LOOT_ENABLED"] = "Il Razziamento Automatico è stato attivato. Open Sesame ne ha bisogno per funzionare."
+L["AUTO_LOOT_ENABLED"] = "Il saccheggio automatico è stato attivato. Open Sesame ne ha bisogno per funzionare."
+L["CHAT_OPTIONS_IN_COMBAT"] = "Per precauzione, l'Interfaccia Opzioni non può essere aperta durante il combattimento."
 L["CHAT_LOADED"] =
-	"Versione %s. Le impostazioni (inclusa l'opzione per disabilitare questo messaggio) si trovano in Opzioni > AddOn > Open Sesame. Ti piace l'addon? Parlane con un amico! (="
+	"Versione %s. Le impostazioni (inclusa l'opzione per disattivare questo messaggio) si trovano in Opzioni > AddOns > Open Sesame. Ti piace l'add-on? Parlane a un amico! (="
 
 -- Auto-Opening
-L["PAUSED_BAG_SLOTS"] = "L'apertura automatica è in pausa finché non avrai almeno %d spazi liberi nelle borse."
+L["PAUSED_BAG_SLOTS"] = "L'apertura automatica è in pausa finché non hai almeno %d spazi liberi nelle borse."
 L["RESUMED"] = "L'apertura automatica è ripresa."
 L["INVENTORY_FULL"] = "L'inventario è pieno!"
-L["ITEM_WILL_AUTO_OPEN"] = "%s verrà aperto automaticamente una volta sbloccato."
-L["ITEM_OPEN_MANUALLY"] =
-	"%s deve essere aperto manualmente. Potrebbe contenere un oggetto unico, vincolato alla raccolta o temporaneo, oppure è stato rilasciato da un boss di incursione."
+L["ITEM_WILL_AUTO_OPEN"] = "%s verrà aperto automaticamente non appena sarà sbloccato."
+L["ITEM_IGNORED"] = "%s è nella tua lista ignorati, quindi l'apertura automatica non lo ha toccato."
+L["ITEM_OPEN_MANUALLY"] = "%s è stato lasciato nella finestra del bottino perché tu lo apra."
 
 --------------------------------------------------------------------------------
 -- Features
 --------------------------------------------------------------------------------
 
 L["AUTO_OPENING"] = "Apertura automatica"
-L["AUTO_OPENING_DESC"] =
-	"Apre automaticamente molluschi e contenitori sbloccati quando hai almeno %d spazi liberi nelle borse."
-L["SPEEDY_LOOT"] = "Razziamento rapido"
-L["SPEEDY_LOOT_DESC"] = "Nasconde la finestra del bottino per un razziamento quasi istantaneo."
+L["AUTO_OPENING_DESCRIPTION"] =
+	"Apre automaticamente vongole e contenitori sbloccati quando hai almeno %d spazi liberi nelle borse."
+L["SPEEDY_LOOT"] = "Bottino rapido"
+L["SPEEDY_LOOT_DESCRIPTION"] = "Nasconde la finestra del bottino per raccogliere quasi istantaneamente."
+L["NOTIFICATIONS_DESCRIPTION"] =
+	"Il bottino rapido nasconde la finestra del bottino, quindi è così che Open Sesame ti dice cosa hai appena raccolto."
+L["LOCKBOXES_DESCRIPTION"] =
+	"I contenitori chiusi richiedono l'abilità Scassinare di un ladro prima di potersi aprire. Queste opzioni mostrano cosa richiede ogni scrigno e ti avvisano quando ce n'è uno in attesa."
 L["LOOT_SOUNDS"] = "Suono del bottino"
-L["LOOT_SOUNDS_DESC"] = "Riproduce un suono speciale quando raccogli un oggetto di qualità Non Comune o superiore."
+L["LOOT_SOUNDS_DESCRIPTION"] = "Riproduce un suono in base alle impostazioni di qualità che scegli."
+L["LOOT_TOASTS"] = "Avvisi del bottino"
+L["LOOT_TOASTS_DESCRIPTION"] =
+	"Mostra un breve avviso a schermo per gli oggetti che raccogli, dato che il bottino rapido nasconde la finestra del bottino. Spostare il bottino fuori dalla chat lascia la finestra libera per le conversazioni e i messaggi che contano."
 
 --------------------------------------------------------------------------------
 -- Tooltip
@@ -48,27 +64,115 @@ L["LOOT_SOUNDS_DESC"] = "Riproduce un suono speciale quando raccogli un oggetto 
 L["KEYBIND_LEFT_CLICK"] = "Clic sinistro"
 L["KEYBIND_RIGHT_CLICK"] = "Clic destro"
 L["KEYBIND_MIDDLE_CLICK"] = "Clic centrale"
-L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + Clic centrale"
-L["ACTION_TOGGLE"] = "Attiva/Disattiva"
+L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Maiusc + Clic centrale"
+L["ACTION_TOGGLE"] = "Attiva o disattiva"
 L["TOOLTIP_OPTIONS_TITLE"] = "Opzioni di Open Sesame"
+L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"] = "Richiede Scassinare"
+L["TOOLTIP_YOUR_LOCKPICKING_LABEL"] = "Il tuo Scassinare"
+L["TOOLTIP_LOCKED_ITEMS"] = "Oggetti chiusi"
 
 --------------------------------------------------------------------------------
 -- Options
 --------------------------------------------------------------------------------
 
-L["OPTIONS_INTRO"] =
-	"Open Sesame apre automaticamente molluschi, cassette di sicurezza e contenitori sbloccati nelle tue borse. Il Razziamento rapido integrato nasconde la finestra del bottino per una raccolta quasi istantanea. Meno clic, più gioco."
-L["OPTIONS_ENABLE_WELCOME"] = "Abilita il messaggio di benvenuto"
-L["OPTIONS_ENABLE_MINIMAP"] = "Abilita pulsante minimappa"
-L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Abilita le notifiche delle cassette di sicurezza"
-L["OPTIONS_ENABLE_AUTO_OPENING"] = "Abilita apertura automatica"
-L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "Abilita razziamento rapido"
-L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "Abilita suono del bottino"
-L["OPTIONS_LOOT_SOUND_THRESHOLD"] = "Qualità minima per il suono del bottino"
+-- General Panel
+L["OPTIONS_DESCRIPTION"] =
+	"Apre automaticamente vongole, scrigni chiusi e contenitori sbloccati nelle tue borse, senza alcun clic. Il Bottino rapido integrato nasconde la finestra del bottino per una raccolta automatica quasi istantanea. Meno clic, più gioco."
+L["OPTIONS_ENABLE_WELCOME"] = "Attiva messaggio di benvenuto"
+L["OPTIONS_ENABLE_MINIMAP"] = "Attiva pulsante della mini-mappa"
+
+-- Auto-Opening
+L["OPTIONS_ENABLE_AUTO_OPENING"] = "Attiva apertura automatica"
+L["OPTIONS_AUTO_OPENING_WHERE"] = "Dove"
+L["OPTIONS_ANYWHERE"] = "Ovunque"
+L["OPTIONS_OUTSIDE_INSTANCES"] = "Fuori dalle istanze"
+L["OPTIONS_AUTO_OPENING_GROUP"] = "Gruppo"
+L["OPTIONS_SOLO_OR_GROUPED"] = "Da solo o in gruppo"
+L["OPTIONS_SOLO_ONLY"] = "Solo da solo"
+
+-- Speedy Loot
+L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "Attiva bottino rapido"
+
+-- Lockboxes
+L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"] = "Attiva descrizioni degli scrigni"
+L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Attiva notifiche degli scrigni"
+L["OPTIONS_SHOW_FOR"] = "Mostra per"
+L["OPTIONS_FOR_ROGUES"] = "Per i ladri"
+L["OPTIONS_FOR_ALL_CHARACTERS"] = "Per tutti i personaggi"
+
+-- Notifications
+L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "Attiva suono del bottino"
 L["OPTIONS_TEST_LOOT_SOUND"] = "Riproduci il suono del bottino."
-L["OPTIONS_COMMANDS_HEADER"] = "/Comandi"
-L["OPTIONS_CMD_OS"] = "/os"
-L["OPTIONS_CMD_OS_DESCRIPTION"] = "Apre l'interfaccia delle opzioni di Open Sesame."
+L["OPTIONS_ENABLE_PICK_POCKET_SOUND"] = "Attiva suono di Borseggiare"
+L["OPTIONS_MINIMUM_QUALITY"] = "Qualità minima"
+
+-- Loot Toasts
+L["OPTIONS_ENABLE_LOOT_TOASTS"] = "Attiva avvisi del bottino"
+-- The threshold bypasses, then the money row, in the order the panel lists them.
+L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"] = "Mostra sempre gli oggetti legati al raccoglimento"
+L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"] = "Mostra sempre gli oggetti delle missioni"
+L["OPTIONS_ALWAYS_SHOW_RECIPES"] = "Mostra sempre le ricette"
+L["OPTIONS_ALWAYS_SHOW_MOUNTS"] = "Mostra sempre le cavalcature"
+L["OPTIONS_ALWAYS_SHOW_PETS"] = "Mostra sempre i famigli"
+L["OPTIONS_ALWAYS_SHOW_KEYS"] = "Mostra sempre le chiavi"
+L["OPTIONS_ALWAYS_SHOW_BAGS"] = "Mostra sempre le borse"
+L["OPTIONS_ALWAYS_SHOW_CONTAINERS"] = "Mostra sempre i contenitori"
+L["OPTIONS_ALWAYS_SHOW_MONEY"] = "Mostra sempre il denaro"
+L["OPTIONS_LOOT_TOAST_MAX_ITEMS"] = "Numero massimo di oggetti mostrati"
+L["OPTIONS_UNLIMITED"] = "Illimitato"
+L["OPTIONS_LOOT_TOAST_DURATION"] = "Secondi a schermo"
+L["OPTIONS_LOOT_TOAST_GROWTH"] = "Direzione di crescita"
+L["OPTIONS_GROW_UP"] = "Verso l'alto"
+L["OPTIONS_GROW_DOWN"] = "Verso il basso"
+L["OPTIONS_LOOT_TOAST_ALIGN"] = "Allinea oggetti"
+L["OPTIONS_ALIGN_LEFT"] = "Sinistra"
+L["OPTIONS_ALIGN_RIGHT"] = "Destra"
+L["OPTIONS_LOOT_TOAST_FONT"] = "Carattere"
+L["OPTIONS_FONT_DEFAULT"] = "Predefinito"
+L["OPTIONS_LOOT_TOAST_FONT_SIZE"] = "Dimensione del carattere"
+L["OPTIONS_LOOT_TOAST_OUTLINE"] = "Contorno del carattere"
+L["OPTIONS_FONT_OUTLINE_NONE"] = "Nessuno"
+L["OPTIONS_FONT_OUTLINE_OUTLINE"] = "Contorno"
+L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"] = "Contorno spesso"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME"] = "Monocromatico"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"] = "Contorno monocromatico"
+L["OPTIONS_TOASTS_UNLOCK"] = "Sblocca posizione"
+L["OPTIONS_TOASTS_LOCK"] = "Blocca posizione"
+L["OPTIONS_TOASTS_RESET"] = "Reimposta posizione"
+L["OPTIONS_TOASTS_CLICK_DRAG"] = "Clic + Trascina per posizionare"
+L["OPTIONS_TOASTS_RIGHT_CLICK_LOCK"] = "Clic destro per bloccare"
+L["OPTIONS_TOASTS_DISABLE_BUTTON"] = "Disattiva avvisi del bottino"
+L["OPTIONS_TOASTS_EXAMPLE_ITEM"] = "Oggetto di esempio"
+
+-- Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
+L["OPTIONS_COMMAND"] = "/os"
+L["OPTIONS_COMMAND_DESCRIPTION"] = "Apre l'Interfaccia Opzioni di questo add-on."
+
+-- Ignore List
+L["OPTIONS_IGNORE_LIST_DESCRIPTION"] =
+	"Gli oggetti in questa lista vengono lasciati stare: il bottino rapido li lascia nella finestra del bottino e l'apertura automatica non li apre mai. La lista è condivisa da tutti i tuoi personaggi."
+L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"] = "Attiva notifiche della lista ignorati"
+L["OPTIONS_IGNORE_LIST_ADD"] = "Aggiungi oggetto"
+L["OPTIONS_IGNORE_LIST_ADD_HINT"] = "Trascina qui un oggetto, oppure incolla un collegamento o un ID oggetto."
+L["OPTIONS_IGNORE_LIST_REMOVE"] = "Rimuovi questo oggetto dalla lista ignorati."
+L["OPTIONS_IGNORE_LIST_RESTORE"] = "Ripristina predefiniti"
+L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"] =
+	"Ripristinare la lista ignorati predefinita? Gli oggetti che hai aggiunto verranno rimossi."
+L["OPTIONS_IGNORE_REASON_RAID"] =
+	"Lasciato da un boss di incursione. Un contenitore non aperto può ancora essere scambiato o venduto, spesso per più di quanto contiene."
+L["OPTIONS_IGNORE_REASON_QUEST"] =
+	"Può contenere un oggetto di missione unico. Aprirlo può fallire con un errore se ne possiedi già uno."
+L["OPTIONS_IGNORE_REASON_RECIPE"] =
+	"Può contenere una ricetta legata al raccoglimento. Un contenitore non aperto può ancora essere scambiato o venduto."
+L["OPTIONS_IGNORE_REASON_GEAR"] =
+	"Può contenere un'arma o un pezzo di armatura legato al raccoglimento. Un contenitore non aperto può ancora essere scambiato o venduto."
+L["OPTIONS_IGNORE_REASON_HOLIDAY"] =
+	"Può contenere un oggetto festivo legato al raccoglimento. Un contenitore non aperto può ancora essere scambiato o venduto."
+L["OPTIONS_IGNORE_REASON_ITEM"] =
+	"Può contenere un oggetto legato al raccoglimento. Un contenitore non aperto può ancora essere scambiato o venduto."
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Feedback e supporto"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/koKR.lua
+++ b/Locales/koKR.lua
@@ -10,37 +10,52 @@ end
 L["ADDON_TITLE"] = "Open Sesame"
 L["STATUS_ENABLED"] = "활성화됨"
 L["STATUS_DISABLED"] = "비활성화됨"
-L["STATUS_PAUSED"] = "일시정지"
+L["STATUS_PAUSED"] = "일시 중지됨"
+
+--------------------------------------------------------------------------------
+-- Panel Tabs
+--------------------------------------------------------------------------------
+
+L["TAB_NOTIFICATIONS"] = "알림"
+L["TAB_LOCKBOXES"] = "잠긴 상자"
+L["TAB_IGNORE_LIST"] = "제외 목록"
 
 --------------------------------------------------------------------------------
 -- Chat Messages
 --------------------------------------------------------------------------------
 
 -- System
-L["AUTO_LOOT_ENABLED"] = "자동 줍기가 활성화되었습니다. Open Sesame가 작동하려면 필요합니다."
+L["AUTO_LOOT_ENABLED"] = "자동 획득이 활성화되었습니다. Open Sesame가 작동하려면 필요합니다."
+L["CHAT_OPTIONS_IN_COMBAT"] = "안전을 위해 전투 중에는 설정 화면을 열 수 없습니다."
 L["CHAT_LOADED"] =
-	"버전 %s. 설정(이 메시지를 비활성화하는 옵션 포함)은 옵션 > 애드온 > Open Sesame에서 찾을 수 있습니다. 애드온이 마음에 드시나요? 친구에게 알려주세요! (="
+	"버전 %s. 설정(이 메시지를 끄는 옵션 포함)은 옵션 > 애드온 > Open Sesame에서 찾을 수 있습니다. 애드온이 마음에 드시나요? 친구에게 알려주세요! (="
 
 -- Auto-Opening
-L["PAUSED_BAG_SLOTS"] =
-	"자동 열기가 가방에 최소 %d칸의 빈 공간이 생길 때까지 일시정지됩니다."
+L["PAUSED_BAG_SLOTS"] = "가방 빈 칸이 %d칸 이상 생길 때까지 자동 열기가 일시 중지됩니다."
 L["RESUMED"] = "자동 열기가 재개되었습니다."
 L["INVENTORY_FULL"] = "가방이 가득 찼습니다!"
-L["ITEM_WILL_AUTO_OPEN"] = "%s|1이;가; 잠금 해제되면 자동으로 열립니다."
-L["ITEM_OPEN_MANUALLY"] =
-	"%s|1은;는; 수동으로 열어야 합니다. 고유, 획득 시 귀속, 또는 임시 아이템을 포함하고 있거나 공격대 우두머리에게서 획득한 것일 수 있습니다."
+L["ITEM_WILL_AUTO_OPEN"] = "%s은(는) 잠금이 풀리는 즉시 자동으로 열립니다."
+L["ITEM_IGNORED"] = "%s은(는) 제외 목록에 있어 자동 열기가 건드리지 않았습니다."
+L["ITEM_OPEN_MANUALLY"] = "%s은(는) 직접 열 수 있도록 획득 창에 남겨두었습니다."
 
 --------------------------------------------------------------------------------
 -- Features
 --------------------------------------------------------------------------------
 
 L["AUTO_OPENING"] = "자동 열기"
-L["AUTO_OPENING_DESC"] =
-	"가방에 빈 공간이 최소 %d칸 이상일 때 조개와 잠금 해제된 상자를 자동으로 엽니다."
-L["SPEEDY_LOOT"] = "빠른 전리품"
-L["SPEEDY_LOOT_DESC"] = "전리품 창을 숨겨 거의 즉시 아이템을 획득합니다."
-L["LOOT_SOUNDS"] = "전리품 소리"
-L["LOOT_SOUNDS_DESC"] = "고급 이상 품질의 아이템을 획득할 때 특별한 소리를 재생합니다."
+L["AUTO_OPENING_DESCRIPTION"] =
+	"가방 빈 칸이 %d칸 이상일 때 조개와 잠기지 않은 상자를 자동으로 엽니다."
+L["SPEEDY_LOOT"] = "빠른 획득"
+L["SPEEDY_LOOT_DESCRIPTION"] = "획득 창을 숨겨 거의 즉시 아이템을 획득합니다."
+L["NOTIFICATIONS_DESCRIPTION"] =
+	"빠른 획득이 획득 창을 숨기므로, Open Sesame는 이 방법으로 방금 무엇을 주웠는지 알려줍니다."
+L["LOCKBOXES_DESCRIPTION"] =
+	"잠긴 상자는 도적의 자물쇠 따기 숙련이 있어야 열 수 있습니다. 이 설정은 각 상자에 필요한 수치를 보여주고, 기다리는 상자가 있으면 알려줍니다."
+L["LOOT_SOUNDS"] = "획득 소리"
+L["LOOT_SOUNDS_DESCRIPTION"] = "원하는 품질 설정에 따라 소리를 재생합니다."
+L["LOOT_TOASTS"] = "획득 알림"
+L["LOOT_TOASTS_DESCRIPTION"] =
+	"빠른 획득이 획득 창을 숨기므로, 주운 아이템을 화면에 짧게 표시합니다. 획득 내역을 대화창 밖으로 옮기면 대화와 중요한 메시지를 위한 공간이 생깁니다."
 
 --------------------------------------------------------------------------------
 -- Tooltip
@@ -48,28 +63,117 @@ L["LOOT_SOUNDS_DESC"] = "고급 이상 품질의 아이템을 획득할 때 특�
 
 L["KEYBIND_LEFT_CLICK"] = "좌클릭"
 L["KEYBIND_RIGHT_CLICK"] = "우클릭"
-L["KEYBIND_MIDDLE_CLICK"] = "가운데 클릭"
-L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + 가운데 클릭"
+L["KEYBIND_MIDDLE_CLICK"] = "휠클릭"
+L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + 휠클릭"
 L["ACTION_TOGGLE"] = "전환"
-L["TOOLTIP_OPTIONS_TITLE"] = "Open Sesame 옵션"
+L["TOOLTIP_OPTIONS_TITLE"] = "Open Sesame 설정"
+L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"] = "필요 자물쇠 따기"
+L["TOOLTIP_YOUR_LOCKPICKING_LABEL"] = "내 자물쇠 따기"
+L["TOOLTIP_LOCKED_ITEMS"] = "잠긴 아이템"
 
 --------------------------------------------------------------------------------
 -- Options
 --------------------------------------------------------------------------------
 
-L["OPTIONS_INTRO"] =
-	"Open Sesame가 가방에 있는 조개, 자물쇠 상자, 잠금 해제된 상자를 자동으로 엽니다. 내장된 빠른 전리품 기능이 전리품 창을 숨겨 거의 즉시 획득할 수 있게 합니다. 클릭은 줄이고, 플레이는 늘리세요."
-L["OPTIONS_ENABLE_WELCOME"] = "환영 메시지 활성화"
-L["OPTIONS_ENABLE_MINIMAP"] = "미니맵 버튼 활성화"
-L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "자물쇠 상자 알림 활성화"
-L["OPTIONS_ENABLE_AUTO_OPENING"] = "자동 열기 활성화"
-L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "빠른 전리품 활성화"
-L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "전리품 소리 활성화"
-L["OPTIONS_LOOT_SOUND_THRESHOLD"] = "전리품 소리 최소 품질"
-L["OPTIONS_TEST_LOOT_SOUND"] = "전리품 소리를 재생합니다."
-L["OPTIONS_COMMANDS_HEADER"] = "/명령어"
-L["OPTIONS_CMD_OS"] = "/os"
-L["OPTIONS_CMD_OS_DESCRIPTION"] = "Open Sesame 옵션 창을 엽니다."
+-- General Panel
+L["OPTIONS_DESCRIPTION"] =
+	"가방 속 조개, 잠긴 상자, 잠기지 않은 상자를 클릭 없이 자동으로 엽니다. 내장된 빠른 획득이 획득 창을 숨겨 거의 즉시 자동으로 아이템을 챙깁니다. 클릭은 줄이고, 플레이는 늘리세요."
+L["OPTIONS_ENABLE_WELCOME"] = "시작 메시지 사용"
+L["OPTIONS_ENABLE_MINIMAP"] = "미니맵 버튼 사용"
+
+-- Auto-Opening
+L["OPTIONS_ENABLE_AUTO_OPENING"] = "자동 열기 사용"
+L["OPTIONS_AUTO_OPENING_WHERE"] = "장소"
+L["OPTIONS_ANYWHERE"] = "모든 장소"
+L["OPTIONS_OUTSIDE_INSTANCES"] = "인스턴스 밖에서만"
+L["OPTIONS_AUTO_OPENING_GROUP"] = "파티"
+L["OPTIONS_SOLO_OR_GROUPED"] = "솔로 또는 파티"
+L["OPTIONS_SOLO_ONLY"] = "솔로일 때만"
+
+-- Speedy Loot
+L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "빠른 획득 사용"
+
+-- Lockboxes
+L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"] = "잠긴 상자 툴팁 사용"
+L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "잠긴 상자 알림 사용"
+L["OPTIONS_SHOW_FOR"] = "표시 대상"
+L["OPTIONS_FOR_ROGUES"] = "도적만"
+L["OPTIONS_FOR_ALL_CHARACTERS"] = "모든 캐릭터"
+
+-- Notifications
+L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "획득 소리 사용"
+L["OPTIONS_TEST_LOOT_SOUND"] = "획득 소리를 재생합니다."
+L["OPTIONS_ENABLE_PICK_POCKET_SOUND"] = "소매치기 소리 사용"
+L["OPTIONS_MINIMUM_QUALITY"] = "최소 품질"
+
+-- Loot Toasts
+L["OPTIONS_ENABLE_LOOT_TOASTS"] = "획득 알림 사용"
+-- The threshold bypasses, then the money row, in the order the panel lists them.
+L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"] = "획득 시 귀속 아이템 항상 표시"
+L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"] = "퀘스트 아이템 항상 표시"
+L["OPTIONS_ALWAYS_SHOW_RECIPES"] = "제조법 항상 표시"
+L["OPTIONS_ALWAYS_SHOW_MOUNTS"] = "탈것 항상 표시"
+L["OPTIONS_ALWAYS_SHOW_PETS"] = "애완동물 항상 표시"
+L["OPTIONS_ALWAYS_SHOW_KEYS"] = "열쇠 항상 표시"
+L["OPTIONS_ALWAYS_SHOW_BAGS"] = "가방 항상 표시"
+L["OPTIONS_ALWAYS_SHOW_CONTAINERS"] = "상자 항상 표시"
+L["OPTIONS_ALWAYS_SHOW_MONEY"] = "골드 항상 표시"
+L["OPTIONS_LOOT_TOAST_MAX_ITEMS"] = "최대 표시 개수"
+L["OPTIONS_UNLIMITED"] = "무제한"
+L["OPTIONS_LOOT_TOAST_DURATION"] = "화면 표시 시간(초)"
+L["OPTIONS_LOOT_TOAST_GROWTH"] = "확장 방향"
+L["OPTIONS_GROW_UP"] = "위로"
+L["OPTIONS_GROW_DOWN"] = "아래로"
+L["OPTIONS_LOOT_TOAST_ALIGN"] = "항목 정렬"
+L["OPTIONS_ALIGN_LEFT"] = "왼쪽"
+L["OPTIONS_ALIGN_RIGHT"] = "오른쪽"
+L["OPTIONS_LOOT_TOAST_FONT"] = "글꼴"
+L["OPTIONS_FONT_DEFAULT"] = "기본값"
+L["OPTIONS_LOOT_TOAST_FONT_SIZE"] = "글꼴 크기"
+L["OPTIONS_LOOT_TOAST_OUTLINE"] = "글꼴 외곽선"
+L["OPTIONS_FONT_OUTLINE_NONE"] = "없음"
+L["OPTIONS_FONT_OUTLINE_OUTLINE"] = "외곽선"
+L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"] = "굵은 외곽선"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME"] = "단색"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"] = "단색 외곽선"
+L["OPTIONS_TOASTS_UNLOCK"] = "위치 잠금 해제"
+L["OPTIONS_TOASTS_LOCK"] = "위치 잠금"
+L["OPTIONS_TOASTS_RESET"] = "위치 초기화"
+L["OPTIONS_TOASTS_CLICK_DRAG"] = "클릭 + 드래그로 위치 지정"
+L["OPTIONS_TOASTS_RIGHT_CLICK_LOCK"] = "우클릭하여 잠금"
+L["OPTIONS_TOASTS_DISABLE_BUTTON"] = "획득 알림 끄기"
+L["OPTIONS_TOASTS_EXAMPLE_ITEM"] = "예시 아이템"
+
+-- Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
+L["OPTIONS_COMMAND"] = "/os"
+L["OPTIONS_COMMAND_DESCRIPTION"] = "이 애드온의 설정 화면을 엽니다."
+
+-- Ignore List
+L["OPTIONS_IGNORE_LIST_DESCRIPTION"] =
+	"이 목록의 아이템은 건드리지 않습니다. 빠른 획득은 획득 창에 남겨두고, 자동 열기는 절대 열지 않습니다. 목록은 모든 캐릭터가 공유합니다."
+L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"] = "제외 목록 알림 사용"
+L["OPTIONS_IGNORE_LIST_ADD"] = "아이템 추가"
+L["OPTIONS_IGNORE_LIST_ADD_HINT"] =
+	"아이템을 여기로 끌어오거나, 아이템 링크 또는 아이템 ID를 붙여넣으세요."
+L["OPTIONS_IGNORE_LIST_REMOVE"] = "이 아이템을 제외 목록에서 제거합니다."
+L["OPTIONS_IGNORE_LIST_RESTORE"] = "기본값 복원"
+L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"] =
+	"기본 제외 목록을 복원할까요? 직접 추가한 아이템은 제거됩니다."
+L["OPTIONS_IGNORE_REASON_RAID"] =
+	"공격대 우두머리가 떨어뜨립니다. 열지 않은 상자는 여전히 거래하거나 판매할 수 있으며, 내용물보다 비싼 경우가 많습니다."
+L["OPTIONS_IGNORE_REASON_QUEST"] =
+	"고유 퀘스트 아이템이 들어 있을 수 있습니다. 이미 갖고 있다면 열 때 오류가 날 수 있습니다."
+L["OPTIONS_IGNORE_REASON_RECIPE"] =
+	"획득 시 귀속되는 제조법이 들어 있을 수 있습니다. 열지 않은 상자는 여전히 거래하거나 판매할 수 있습니다."
+L["OPTIONS_IGNORE_REASON_GEAR"] =
+	"획득 시 귀속되는 무기나 방어구가 들어 있을 수 있습니다. 열지 않은 상자는 여전히 거래하거나 판매할 수 있습니다."
+L["OPTIONS_IGNORE_REASON_HOLIDAY"] =
+	"획득 시 귀속되는 축제 아이템이 들어 있을 수 있습니다. 열지 않은 상자는 여전히 거래하거나 판매할 수 있습니다."
+L["OPTIONS_IGNORE_REASON_ITEM"] =
+	"획득 시 귀속되는 아이템이 들어 있을 수 있습니다. 열지 않은 상자는 여전히 거래하거나 판매할 수 있습니다."
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "피드백 및 지원"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/ptBR.lua
+++ b/Locales/ptBR.lua
@@ -13,34 +13,49 @@ L["STATUS_DISABLED"] = "Desativado"
 L["STATUS_PAUSED"] = "Pausado"
 
 --------------------------------------------------------------------------------
+-- Panel Tabs
+--------------------------------------------------------------------------------
+
+L["TAB_NOTIFICATIONS"] = "Notificações"
+L["TAB_LOCKBOXES"] = "Cofres trancados"
+L["TAB_IGNORE_LIST"] = "Lista de ignorados"
+
+--------------------------------------------------------------------------------
 -- Chat Messages
 --------------------------------------------------------------------------------
 
 -- System
-L["AUTO_LOOT_ENABLED"] = "O Saque Automático foi ativado. O Open Sesame precisa dele para funcionar."
+L["AUTO_LOOT_ENABLED"] = "O saque automático foi ativado. O Open Sesame precisa dele para funcionar."
+L["CHAT_OPTIONS_IN_COMBAT"] = "Por precaução, a Interface de Opções não pode ser aberta durante o combate."
 L["CHAT_LOADED"] =
-	"Versão %s. As configurações (incluindo a opção de desativar esta mensagem) podem ser encontradas em Opções > AddOns > Open Sesame. Gostando do addon? Conte para um amigo! (="
+	"Versão %s. As configurações (incluindo a opção de desativar esta mensagem) estão em Opções > AddOns > Open Sesame. Gostou do add-on? Conte para um amigo! (="
 
 -- Auto-Opening
-L["PAUSED_BAG_SLOTS"] =
-	"A abertura automática está pausada até que você tenha pelo menos %d espaços livres na bolsa."
+L["PAUSED_BAG_SLOTS"] = "A abertura automática está pausada até você ter pelo menos %d espaços livres na mochila."
 L["RESUMED"] = "A abertura automática foi retomada."
 L["INVENTORY_FULL"] = "O inventário está cheio!"
-L["ITEM_WILL_AUTO_OPEN"] = "%s será aberto automaticamente quando for desbloqueado."
-L["ITEM_OPEN_MANUALLY"] =
-	"%s precisa ser aberto manualmente. Pode conter um item Único, Vinculado ao Coletar ou Temporário, ou foi deixado por um chefe de raide."
+L["ITEM_WILL_AUTO_OPEN"] = "%s será aberto automaticamente assim que for destrancado."
+L["ITEM_IGNORED"] = "%s está na sua lista de ignorados, então a abertura automática não mexeu nele."
+L["ITEM_OPEN_MANUALLY"] = "%s foi deixado na janela de saque para você abrir."
 
 --------------------------------------------------------------------------------
 -- Features
 --------------------------------------------------------------------------------
 
 L["AUTO_OPENING"] = "Abertura automática"
-L["AUTO_OPENING_DESC"] =
-	"Abre automaticamente mariscos e recipientes desbloqueados quando você tem pelo menos %d espaços livres na bolsa."
+L["AUTO_OPENING_DESCRIPTION"] =
+	"Abre automaticamente mariscos e recipientes destrancados quando você tem pelo menos %d espaços livres na mochila."
 L["SPEEDY_LOOT"] = "Saque rápido"
-L["SPEEDY_LOOT_DESC"] = "Oculta a janela de saque para coletar itens quase instantaneamente."
+L["SPEEDY_LOOT_DESCRIPTION"] = "Oculta a janela de saque para coletar quase instantaneamente."
+L["NOTIFICATIONS_DESCRIPTION"] =
+	"O saque rápido oculta a janela de saque, então é assim que o Open Sesame conta o que você acabou de pegar."
+L["LOCKBOXES_DESCRIPTION"] =
+	"Recipientes trancados precisam da perícia Arrombamento de um ladino para abrir. Estas opções mostram o que cada cofre exige e avisam quando há um esperando."
 L["LOOT_SOUNDS"] = "Som de saque"
-L["LOOT_SOUNDS_DESC"] = "Toca um som especial quando você coleta um item de qualidade Incomum ou superior."
+L["LOOT_SOUNDS_DESCRIPTION"] = "Toca um som conforme as configurações de qualidade que você escolher."
+L["LOOT_TOASTS"] = "Avisos de saque"
+L["LOOT_TOASTS_DESCRIPTION"] =
+	"Mostra um aviso rápido na tela para os itens que você saqueia, já que o saque rápido oculta a janela de saque. Tirar o saque do chat libera a janela para conversas e para as mensagens que importam."
 
 --------------------------------------------------------------------------------
 -- Tooltip
@@ -52,24 +67,112 @@ L["KEYBIND_MIDDLE_CLICK"] = "Clique do meio"
 L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + Clique do meio"
 L["ACTION_TOGGLE"] = "Alternar"
 L["TOOLTIP_OPTIONS_TITLE"] = "Opções do Open Sesame"
+L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"] = "Requer Arrombamento"
+L["TOOLTIP_YOUR_LOCKPICKING_LABEL"] = "Seu Arrombamento"
+L["TOOLTIP_LOCKED_ITEMS"] = "Itens trancados"
 
 --------------------------------------------------------------------------------
 -- Options
 --------------------------------------------------------------------------------
 
-L["OPTIONS_INTRO"] =
-	"O Open Sesame abre automaticamente mariscos, caixas trancadas e recipientes desbloqueados nas suas bolsas. O Saque rápido integrado oculta a janela de saque para uma coleta quase instantânea. Menos cliques, mais tempo de jogo."
+-- General Panel
+L["OPTIONS_DESCRIPTION"] =
+	"Abre automaticamente mariscos, cofres trancados e recipientes destrancados nas suas mochilas, sem precisar clicar. O Saque rápido integrado oculta a janela de saque para uma coleta automática quase instantânea. Menos cliques, mais jogo."
 L["OPTIONS_ENABLE_WELCOME"] = "Ativar mensagem de boas-vindas"
 L["OPTIONS_ENABLE_MINIMAP"] = "Ativar botão do minimapa"
-L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Ativar notificações de caixas trancadas"
+
+-- Auto-Opening
 L["OPTIONS_ENABLE_AUTO_OPENING"] = "Ativar abertura automática"
+L["OPTIONS_AUTO_OPENING_WHERE"] = "Onde"
+L["OPTIONS_ANYWHERE"] = "Em qualquer lugar"
+L["OPTIONS_OUTSIDE_INSTANCES"] = "Fora de instâncias"
+L["OPTIONS_AUTO_OPENING_GROUP"] = "Grupo"
+L["OPTIONS_SOLO_OR_GROUPED"] = "Sozinho ou em grupo"
+L["OPTIONS_SOLO_ONLY"] = "Somente sozinho"
+
+-- Speedy Loot
 L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "Ativar saque rápido"
+
+-- Lockboxes
+L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"] = "Ativar dicas de cofres"
+L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Ativar notificações de cofres"
+L["OPTIONS_SHOW_FOR"] = "Mostrar para"
+L["OPTIONS_FOR_ROGUES"] = "Para ladinos"
+L["OPTIONS_FOR_ALL_CHARACTERS"] = "Para todos os personagens"
+
+-- Notifications
 L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "Ativar som de saque"
-L["OPTIONS_LOOT_SOUND_THRESHOLD"] = "Qualidade mínima para o som de saque"
 L["OPTIONS_TEST_LOOT_SOUND"] = "Tocar o som de saque."
-L["OPTIONS_COMMANDS_HEADER"] = "/Comandos"
-L["OPTIONS_CMD_OS"] = "/os"
-L["OPTIONS_CMD_OS_DESCRIPTION"] = "Abre a interface de opções do Open Sesame."
+L["OPTIONS_ENABLE_PICK_POCKET_SOUND"] = "Ativar som de Furtar"
+L["OPTIONS_MINIMUM_QUALITY"] = "Qualidade mínima"
+
+-- Loot Toasts
+L["OPTIONS_ENABLE_LOOT_TOASTS"] = "Ativar avisos de saque"
+-- The threshold bypasses, then the money row, in the order the panel lists them.
+L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"] = "Sempre mostrar itens ligados ao coletar"
+L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"] = "Sempre mostrar itens de missão"
+L["OPTIONS_ALWAYS_SHOW_RECIPES"] = "Sempre mostrar receitas"
+L["OPTIONS_ALWAYS_SHOW_MOUNTS"] = "Sempre mostrar montarias"
+L["OPTIONS_ALWAYS_SHOW_PETS"] = "Sempre mostrar mascotes"
+L["OPTIONS_ALWAYS_SHOW_KEYS"] = "Sempre mostrar chaves"
+L["OPTIONS_ALWAYS_SHOW_BAGS"] = "Sempre mostrar mochilas"
+L["OPTIONS_ALWAYS_SHOW_CONTAINERS"] = "Sempre mostrar recipientes"
+L["OPTIONS_ALWAYS_SHOW_MONEY"] = "Sempre mostrar dinheiro"
+L["OPTIONS_LOOT_TOAST_MAX_ITEMS"] = "Máximo de itens exibidos"
+L["OPTIONS_UNLIMITED"] = "Ilimitado"
+L["OPTIONS_LOOT_TOAST_DURATION"] = "Segundos na tela"
+L["OPTIONS_LOOT_TOAST_GROWTH"] = "Direção de crescimento"
+L["OPTIONS_GROW_UP"] = "Para cima"
+L["OPTIONS_GROW_DOWN"] = "Para baixo"
+L["OPTIONS_LOOT_TOAST_ALIGN"] = "Alinhar itens"
+L["OPTIONS_ALIGN_LEFT"] = "Esquerda"
+L["OPTIONS_ALIGN_RIGHT"] = "Direita"
+L["OPTIONS_LOOT_TOAST_FONT"] = "Fonte"
+L["OPTIONS_FONT_DEFAULT"] = "Padrão"
+L["OPTIONS_LOOT_TOAST_FONT_SIZE"] = "Tamanho da fonte"
+L["OPTIONS_LOOT_TOAST_OUTLINE"] = "Contorno da fonte"
+L["OPTIONS_FONT_OUTLINE_NONE"] = "Nenhum"
+L["OPTIONS_FONT_OUTLINE_OUTLINE"] = "Contorno"
+L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"] = "Contorno grosso"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME"] = "Monocromático"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"] = "Contorno monocromático"
+L["OPTIONS_TOASTS_UNLOCK"] = "Desbloquear posição"
+L["OPTIONS_TOASTS_LOCK"] = "Bloquear posição"
+L["OPTIONS_TOASTS_RESET"] = "Redefinir posição"
+L["OPTIONS_TOASTS_CLICK_DRAG"] = "Clique + Arraste para posicionar"
+L["OPTIONS_TOASTS_RIGHT_CLICK_LOCK"] = "Clique direito para bloquear"
+L["OPTIONS_TOASTS_DISABLE_BUTTON"] = "Desativar avisos de saque"
+L["OPTIONS_TOASTS_EXAMPLE_ITEM"] = "Item de exemplo"
+
+-- Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
+L["OPTIONS_COMMAND"] = "/os"
+L["OPTIONS_COMMAND_DESCRIPTION"] = "Abre a Interface de Opções deste add-on."
+
+-- Ignore List
+L["OPTIONS_IGNORE_LIST_DESCRIPTION"] =
+	"Os itens desta lista são deixados em paz: o saque rápido os deixa na janela de saque e a abertura automática nunca os abre. A lista é compartilhada por todos os seus personagens."
+L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"] = "Ativar notificações da lista de ignorados"
+L["OPTIONS_IGNORE_LIST_ADD"] = "Adicionar item"
+L["OPTIONS_IGNORE_LIST_ADD_HINT"] = "Arraste um item para cá, ou cole um link de item ou um ID de item."
+L["OPTIONS_IGNORE_LIST_REMOVE"] = "Remover este item da lista de ignorados."
+L["OPTIONS_IGNORE_LIST_RESTORE"] = "Restaurar padrões"
+L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"] =
+	"Restaurar a lista de ignorados padrão? Os itens que você adicionou serão removidos."
+L["OPTIONS_IGNORE_REASON_RAID"] =
+	"Largado por um chefe de raide. Um recipiente fechado ainda pode ser negociado ou vendido, muitas vezes por mais do que o conteúdo."
+L["OPTIONS_IGNORE_REASON_QUEST"] =
+	"Pode conter um item de missão único. Abrir pode falhar com um erro se você já tiver um."
+L["OPTIONS_IGNORE_REASON_RECIPE"] =
+	"Pode conter uma receita ligada ao coletar. Um recipiente fechado ainda pode ser negociado ou vendido."
+L["OPTIONS_IGNORE_REASON_GEAR"] =
+	"Pode conter uma arma ou peça de armadura ligada ao coletar. Um recipiente fechado ainda pode ser negociado ou vendido."
+L["OPTIONS_IGNORE_REASON_HOLIDAY"] =
+	"Pode conter um item de evento ligado ao coletar. Um recipiente fechado ainda pode ser negociado ou vendido."
+L["OPTIONS_IGNORE_REASON_ITEM"] =
+	"Pode conter um item ligado ao coletar. Um recipiente fechado ainda pode ser negociado ou vendido."
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "Feedback e suporte"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/ruRU.lua
+++ b/Locales/ruRU.lua
@@ -10,7 +10,15 @@ end
 L["ADDON_TITLE"] = "Open Sesame"
 L["STATUS_ENABLED"] = "Включено"
 L["STATUS_DISABLED"] = "Отключено"
-L["STATUS_PAUSED"] = "Пауза"
+L["STATUS_PAUSED"] = "Приостановлено"
+
+--------------------------------------------------------------------------------
+-- Panel Tabs
+--------------------------------------------------------------------------------
+
+L["TAB_NOTIFICATIONS"] = "Уведомления"
+L["TAB_LOCKBOXES"] = "Запертые ящики"
+L["TAB_IGNORE_LIST"] = "Список исключений"
 
 --------------------------------------------------------------------------------
 -- Chat Messages
@@ -18,32 +26,44 @@ L["STATUS_PAUSED"] = "Пауза"
 
 -- System
 L["AUTO_LOOT_ENABLED"] =
-	"Автосбор добычи включен. Он необходим для работы Open Sesame."
+	"Автоматический сбор добычи включен. Open Sesame не работает без него."
+L["CHAT_OPTIONS_IN_COMBAT"] =
+	"В целях безопасности интерфейс настроек нельзя открыть в бою."
 L["CHAT_LOADED"] =
-	"Версия %s. Настройки (включая возможность отключить это сообщение) можно найти в Настройки > Аддоны > Open Sesame. Нравится аддон? Расскажите о нем друзьям! (="
+	"Версия %s. Настройки (включая отключение этого сообщения) находятся в разделе Настройки > Дополнения > Open Sesame. Нравится дополнение? Расскажите о нем другу! (="
 
 -- Auto-Opening
 L["PAUSED_BAG_SLOTS"] =
-	"Автоматическое открытие на паузе, пока не освободится хотя бы %d ячеек в сумках."
-L["RESUMED"] = "Автоматическое открытие возобновлено."
-L["INVENTORY_FULL"] = "Инвентарь заполнен!"
+	"Автооткрытие приостановлено, пока не освободится хотя бы %d ячеек в сумках."
+L["RESUMED"] = "Автооткрытие возобновлено."
+L["INVENTORY_FULL"] = "Сумки заполнены!"
 L["ITEM_WILL_AUTO_OPEN"] =
-	"%s будет автоматически открыт после разблокировки."
+	"%s откроется автоматически, как только будет взломан."
+L["ITEM_IGNORED"] =
+	"%s находится в списке исключений, поэтому автооткрытие его не тронуло."
 L["ITEM_OPEN_MANUALLY"] =
-	"%s нужно открыть вручную. Может содержать уникальный, персональный при получении или временный предмет, либо был получен от рейдового босса."
+	"%s оставлен в окне добычи, чтобы вы открыли его сами."
 
 --------------------------------------------------------------------------------
 -- Features
 --------------------------------------------------------------------------------
 
-L["AUTO_OPENING"] = "Автоматическое открытие"
-L["AUTO_OPENING_DESC"] =
-	"Автоматически открывает моллюсков и разблокированные контейнеры, когда в сумках есть как минимум %d свободных ячеек."
+L["AUTO_OPENING"] = "Автооткрытие"
+L["AUTO_OPENING_DESCRIPTION"] =
+	"Автоматически открывает моллюсков и незапертые контейнеры, когда в сумках свободно хотя бы %d ячеек."
 L["SPEEDY_LOOT"] = "Быстрый сбор"
-L["SPEEDY_LOOT_DESC"] = "Скрывает окно добычи для почти мгновенного сбора."
+L["SPEEDY_LOOT_DESCRIPTION"] =
+	"Скрывает окно добычи, чтобы собирать почти мгновенно."
+L["NOTIFICATIONS_DESCRIPTION"] =
+	"Быстрый сбор скрывает окно добычи, поэтому именно так Open Sesame сообщает, что вы только что подобрали."
+L["LOCKBOXES_DESCRIPTION"] =
+	"Запертые контейнеры требуют навыка взлома замков разбойника, прежде чем откроются. Эти настройки показывают, что нужно каждому ящику, и сообщают, когда один из них ждет."
 L["LOOT_SOUNDS"] = "Звук добычи"
-L["LOOT_SOUNDS_DESC"] =
-	"Воспроизводит особый звук при получении предмета необычного или более высокого качества."
+L["LOOT_SOUNDS_DESCRIPTION"] =
+	"Воспроизводит звук в зависимости от выбранной вами настройки качества."
+L["LOOT_TOASTS"] = "Уведомления о добыче"
+L["LOOT_TOASTS_DESCRIPTION"] =
+	"Показывает короткое уведомление на экране для подобранных предметов, ведь быстрый сбор скрывает окно добычи. Когда добыча не идет в чат, окно остается свободным для разговоров и важных сообщений."
 
 --------------------------------------------------------------------------------
 -- Tooltip
@@ -55,25 +75,116 @@ L["KEYBIND_MIDDLE_CLICK"] = "Средний клик"
 L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + Средний клик"
 L["ACTION_TOGGLE"] = "Переключить"
 L["TOOLTIP_OPTIONS_TITLE"] = "Настройки Open Sesame"
+L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"] = "Требуется взлом замков"
+L["TOOLTIP_YOUR_LOCKPICKING_LABEL"] = "Ваш взлом замков"
+L["TOOLTIP_LOCKED_ITEMS"] = "Запертые предметы"
 
 --------------------------------------------------------------------------------
 -- Options
 --------------------------------------------------------------------------------
 
-L["OPTIONS_INTRO"] =
-	"Open Sesame автоматически открывает моллюсков, запертые ящики и разблокированные контейнеры в ваших сумках. Встроенный Быстрый сбор скрывает окно добычи для почти мгновенного сбора. Меньше кликов, больше игры."
-L["OPTIONS_ENABLE_WELCOME"] = "Включить приветственное сообщение"
-L["OPTIONS_ENABLE_MINIMAP"] = "Включить кнопку мини-карты"
-L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Включить уведомления о запертых ящиках"
-L["OPTIONS_ENABLE_AUTO_OPENING"] = "Включить автоматическое открытие"
+-- General Panel
+L["OPTIONS_DESCRIPTION"] =
+	"Автоматически открывает моллюсков, запертые ящики и незапертые контейнеры в ваших сумках, без единого клика. Встроенный быстрый сбор скрывает окно добычи для почти мгновенного автоматического сбора. Меньше кликов, больше игры."
+L["OPTIONS_ENABLE_WELCOME"] = "Показывать приветственное сообщение"
+L["OPTIONS_ENABLE_MINIMAP"] = "Показывать кнопку на мини-карте"
+
+-- Auto-Opening
+L["OPTIONS_ENABLE_AUTO_OPENING"] = "Включить автооткрытие"
+L["OPTIONS_AUTO_OPENING_WHERE"] = "Где"
+L["OPTIONS_ANYWHERE"] = "Везде"
+L["OPTIONS_OUTSIDE_INSTANCES"] = "Вне подземелий"
+L["OPTIONS_AUTO_OPENING_GROUP"] = "Группа"
+L["OPTIONS_SOLO_OR_GROUPED"] = "Один или в группе"
+L["OPTIONS_SOLO_ONLY"] = "Только в одиночку"
+
+-- Speedy Loot
 L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "Включить быстрый сбор"
+
+-- Lockboxes
+L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"] = "Включить подсказки для запертых ящиков"
+L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "Включить уведомления о запертых ящиках"
+L["OPTIONS_SHOW_FOR"] = "Показывать для"
+L["OPTIONS_FOR_ROGUES"] = "Для разбойников"
+L["OPTIONS_FOR_ALL_CHARACTERS"] = "Для всех персонажей"
+
+-- Notifications
 L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "Включить звук добычи"
-L["OPTIONS_LOOT_SOUND_THRESHOLD"] = "Минимальное качество для звука добычи"
 L["OPTIONS_TEST_LOOT_SOUND"] = "Воспроизвести звук добычи."
-L["OPTIONS_COMMANDS_HEADER"] = "/Команды"
-L["OPTIONS_CMD_OS"] = "/os"
-L["OPTIONS_CMD_OS_DESCRIPTION"] = "Открывает интерфейс настроек Open Sesame."
-L["OPTIONS_FEEDBACK"] = "Обратная связь и поддержка"
+L["OPTIONS_ENABLE_PICK_POCKET_SOUND"] = "Включить звук карманной кражи"
+L["OPTIONS_MINIMUM_QUALITY"] = "Минимальное качество"
+
+-- Loot Toasts
+L["OPTIONS_ENABLE_LOOT_TOASTS"] = "Включить уведомления о добыче"
+-- The threshold bypasses, then the money row, in the order the panel lists them.
+L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"] = "Всегда показывать персональные предметы"
+L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"] = "Всегда показывать предметы заданий"
+L["OPTIONS_ALWAYS_SHOW_RECIPES"] = "Всегда показывать рецепты"
+L["OPTIONS_ALWAYS_SHOW_MOUNTS"] = "Всегда показывать средства передвижения"
+L["OPTIONS_ALWAYS_SHOW_PETS"] = "Всегда показывать питомцев"
+L["OPTIONS_ALWAYS_SHOW_KEYS"] = "Всегда показывать ключи"
+L["OPTIONS_ALWAYS_SHOW_BAGS"] = "Всегда показывать сумки"
+L["OPTIONS_ALWAYS_SHOW_CONTAINERS"] = "Всегда показывать контейнеры"
+L["OPTIONS_ALWAYS_SHOW_MONEY"] = "Всегда показывать деньги"
+L["OPTIONS_LOOT_TOAST_MAX_ITEMS"] = "Максимум строк на экране"
+L["OPTIONS_UNLIMITED"] = "Без ограничений"
+L["OPTIONS_LOOT_TOAST_DURATION"] = "Секунд на экране"
+L["OPTIONS_LOOT_TOAST_GROWTH"] = "Направление роста"
+L["OPTIONS_GROW_UP"] = "Вверх"
+L["OPTIONS_GROW_DOWN"] = "Вниз"
+L["OPTIONS_LOOT_TOAST_ALIGN"] = "Выравнивание строк"
+L["OPTIONS_ALIGN_LEFT"] = "Слева"
+L["OPTIONS_ALIGN_RIGHT"] = "Справа"
+L["OPTIONS_LOOT_TOAST_FONT"] = "Шрифт"
+L["OPTIONS_FONT_DEFAULT"] = "По умолчанию"
+L["OPTIONS_LOOT_TOAST_FONT_SIZE"] = "Размер шрифта"
+L["OPTIONS_LOOT_TOAST_OUTLINE"] = "Контур шрифта"
+L["OPTIONS_FONT_OUTLINE_NONE"] = "Нет"
+L["OPTIONS_FONT_OUTLINE_OUTLINE"] = "Контур"
+L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"] = "Толстый контур"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME"] = "Монохромный"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"] = "Монохромный контур"
+L["OPTIONS_TOASTS_UNLOCK"] = "Разблокировать позицию"
+L["OPTIONS_TOASTS_LOCK"] = "Заблокировать позицию"
+L["OPTIONS_TOASTS_RESET"] = "Сбросить позицию"
+L["OPTIONS_TOASTS_CLICK_DRAG"] = "Нажмите и перетащите, чтобы разместить"
+L["OPTIONS_TOASTS_RIGHT_CLICK_LOCK"] = "Правый клик, чтобы заблокировать"
+L["OPTIONS_TOASTS_DISABLE_BUTTON"] = "Отключить уведомления о добыче"
+L["OPTIONS_TOASTS_EXAMPLE_ITEM"] = "Пример предмета"
+
+-- Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
+L["OPTIONS_COMMAND"] = "/os"
+L["OPTIONS_COMMAND_DESCRIPTION"] =
+	"Открывает интерфейс настроек этого дополнения."
+
+-- Ignore List
+L["OPTIONS_IGNORE_LIST_DESCRIPTION"] =
+	"Предметы из этого списка остаются нетронутыми: быстрый сбор оставляет их в окне добычи, а автооткрытие никогда их не открывает. Список общий для всех ваших персонажей."
+L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"] =
+	"Включить уведомления списка исключений"
+L["OPTIONS_IGNORE_LIST_ADD"] = "Добавить предмет"
+L["OPTIONS_IGNORE_LIST_ADD_HINT"] =
+	"Перетащите предмет сюда или вставьте ссылку на предмет либо его ID."
+L["OPTIONS_IGNORE_LIST_REMOVE"] = "Убрать этот предмет из списка исключений."
+L["OPTIONS_IGNORE_LIST_RESTORE"] = "Восстановить по умолчанию"
+L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"] =
+	"Восстановить список исключений по умолчанию? Добавленные вами предметы будут удалены."
+L["OPTIONS_IGNORE_REASON_RAID"] =
+	"Выпадает с рейдового босса. Неоткрытый контейнер можно передать или продать, часто дороже его содержимого."
+L["OPTIONS_IGNORE_REASON_QUEST"] =
+	"Может содержать уникальный предмет задания. Если он у вас уже есть, открытие завершится ошибкой."
+L["OPTIONS_IGNORE_REASON_RECIPE"] =
+	"Может содержать персональный рецепт. Неоткрытый контейнер можно передать или продать."
+L["OPTIONS_IGNORE_REASON_GEAR"] =
+	"Может содержать персональное оружие или часть брони. Неоткрытый контейнер можно передать или продать."
+L["OPTIONS_IGNORE_REASON_HOLIDAY"] =
+	"Может содержать персональный праздничный предмет. Неоткрытый контейнер можно передать или продать."
+L["OPTIONS_IGNORE_REASON_ITEM"] =
+	"Может содержать персональный предмет. Неоткрытый контейнер можно передать или продать."
+
+-- Feedback & Support
+L["OPTIONS_FEEDBACK"] = "Отзывы и поддержка"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"
 L["OPTIONS_DISCORD"] = "Discord"

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -13,32 +13,48 @@ L["STATUS_DISABLED"] = "已禁用"
 L["STATUS_PAUSED"] = "已暂停"
 
 --------------------------------------------------------------------------------
+-- Panel Tabs
+--------------------------------------------------------------------------------
+
+L["TAB_NOTIFICATIONS"] = "通知"
+L["TAB_LOCKBOXES"] = "锁箱"
+L["TAB_IGNORE_LIST"] = "忽略列表"
+
+--------------------------------------------------------------------------------
 -- Chat Messages
 --------------------------------------------------------------------------------
 
 -- System
-L["AUTO_LOOT_ENABLED"] = "自动拾取已启用。Open Sesame 需要它才能正常工作。"
+L["AUTO_LOOT_ENABLED"] = "自动拾取已启用。Open Sesame 需要它才能工作。"
+L["CHAT_OPTIONS_IN_COMBAT"] = "出于安全考虑，战斗中无法打开选项界面。"
 L["CHAT_LOADED"] =
-	"版本 %s。设置（包括禁用此消息的选项）可以在 选项 > 插件 > Open Sesame 中找到。喜欢这个插件吗？告诉你的朋友吧！(="
+	"版本 %s。设置（包括关闭此消息的选项）位于 选项 > 插件 > Open Sesame。喜欢这个插件吗？告诉朋友吧！(="
 
 -- Auto-Opening
-L["PAUSED_BAG_SLOTS"] = "自动开启已暂停，直到背包有至少 %d 个空位。"
+L["PAUSED_BAG_SLOTS"] = "自动开启已暂停，直到你有至少 %d 个空闲背包格。"
 L["RESUMED"] = "自动开启已恢复。"
 L["INVENTORY_FULL"] = "背包已满！"
-L["ITEM_WILL_AUTO_OPEN"] = "%s 将在解锁后自动打开。"
-L["ITEM_OPEN_MANUALLY"] =
-	"%s 需要手动打开。它可能包含唯一、拾取绑定或临时物品，或者是从团队首领处获得的。"
+L["ITEM_WILL_AUTO_OPEN"] = "%s 解锁后将自动开启。"
+L["ITEM_IGNORED"] = "%s 在你的忽略列表中，自动开启没有碰它。"
+L["ITEM_OPEN_MANUALLY"] = "%s 已留在拾取窗口中，供你自行开启。"
 
 --------------------------------------------------------------------------------
 -- Features
 --------------------------------------------------------------------------------
 
 L["AUTO_OPENING"] = "自动开启"
-L["AUTO_OPENING_DESC"] = "当背包有至少 %d 个空位时，自动打开蛤蜊和已解锁的容器。"
+L["AUTO_OPENING_DESCRIPTION"] = "当你有至少 %d 个空闲背包格时，自动开启蚌壳和未上锁的容器。"
 L["SPEEDY_LOOT"] = "快速拾取"
-L["SPEEDY_LOOT_DESC"] = "隐藏拾取窗口以实现近乎即时的拾取。"
+L["SPEEDY_LOOT_DESCRIPTION"] = "隐藏拾取窗口，让拾取几乎瞬间完成。"
+L["NOTIFICATIONS_DESCRIPTION"] =
+	"快速拾取会隐藏拾取窗口，因此 Open Sesame 通过这些方式告诉你刚刚捡到了什么。"
+L["LOCKBOXES_DESCRIPTION"] =
+	"上锁的容器需要潜行者的开锁技能才能打开。这些选项会显示每个锁箱的需求，并在有锁箱等待时提醒你。"
 L["LOOT_SOUNDS"] = "拾取音效"
-L["LOOT_SOUNDS_DESC"] = "拾取到优秀或更高品质的物品时播放特殊音效。"
+L["LOOT_SOUNDS_DESCRIPTION"] = "根据你选择的品质设置播放音效。"
+L["LOOT_TOASTS"] = "拾取提示"
+L["LOOT_TOASTS_DESCRIPTION"] =
+	"由于快速拾取隐藏了拾取窗口，这会为你拾取的物品在屏幕上显示简短提示。把拾取记录移出聊天框，可以让窗口留给对话和真正重要的消息。"
 
 --------------------------------------------------------------------------------
 -- Tooltip
@@ -50,24 +66,109 @@ L["KEYBIND_MIDDLE_CLICK"] = "中键点击"
 L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + 中键点击"
 L["ACTION_TOGGLE"] = "切换"
 L["TOOLTIP_OPTIONS_TITLE"] = "Open Sesame 选项"
+L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"] = "需要开锁"
+L["TOOLTIP_YOUR_LOCKPICKING_LABEL"] = "你的开锁"
+L["TOOLTIP_LOCKED_ITEMS"] = "上锁的物品"
 
 --------------------------------------------------------------------------------
 -- Options
 --------------------------------------------------------------------------------
 
-L["OPTIONS_INTRO"] =
-	"Open Sesame 自动打开背包中的蛤蜊、保险箱和已解锁的容器。内置的快速拾取功能会隐藏拾取窗口，实现近乎即时的拾取。少点点击，多点游戏。"
+-- General Panel
+L["OPTIONS_DESCRIPTION"] =
+	"自动开启背包中的蚌壳、锁箱和未上锁的容器，无需点击。内置的快速拾取会隐藏拾取窗口，让自动拾取几乎瞬间完成。少点鼠标，多玩游戏。"
 L["OPTIONS_ENABLE_WELCOME"] = "启用欢迎消息"
 L["OPTIONS_ENABLE_MINIMAP"] = "启用小地图按钮"
-L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "启用保险箱通知"
+
+-- Auto-Opening
 L["OPTIONS_ENABLE_AUTO_OPENING"] = "启用自动开启"
+L["OPTIONS_AUTO_OPENING_WHERE"] = "地点"
+L["OPTIONS_ANYWHERE"] = "任何地点"
+L["OPTIONS_OUTSIDE_INSTANCES"] = "副本之外"
+L["OPTIONS_AUTO_OPENING_GROUP"] = "队伍"
+L["OPTIONS_SOLO_OR_GROUPED"] = "单人或组队"
+L["OPTIONS_SOLO_ONLY"] = "仅单人"
+
+-- Speedy Loot
 L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "启用快速拾取"
+
+-- Lockboxes
+L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"] = "启用锁箱提示信息"
+L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "启用锁箱通知"
+L["OPTIONS_SHOW_FOR"] = "显示对象"
+L["OPTIONS_FOR_ROGUES"] = "仅潜行者"
+L["OPTIONS_FOR_ALL_CHARACTERS"] = "所有角色"
+
+-- Notifications
 L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "启用拾取音效"
-L["OPTIONS_LOOT_SOUND_THRESHOLD"] = "拾取音效的最低品质"
 L["OPTIONS_TEST_LOOT_SOUND"] = "播放拾取音效。"
-L["OPTIONS_COMMANDS_HEADER"] = "/命令"
-L["OPTIONS_CMD_OS"] = "/os"
-L["OPTIONS_CMD_OS_DESCRIPTION"] = "打开 Open Sesame 选项界面。"
+L["OPTIONS_ENABLE_PICK_POCKET_SOUND"] = "启用偷窃音效"
+L["OPTIONS_MINIMUM_QUALITY"] = "最低品质"
+
+-- Loot Toasts
+L["OPTIONS_ENABLE_LOOT_TOASTS"] = "启用拾取提示"
+-- The threshold bypasses, then the money row, in the order the panel lists them.
+L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"] = "始终显示拾取后绑定的物品"
+L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"] = "始终显示任务物品"
+L["OPTIONS_ALWAYS_SHOW_RECIPES"] = "始终显示配方"
+L["OPTIONS_ALWAYS_SHOW_MOUNTS"] = "始终显示坐骑"
+L["OPTIONS_ALWAYS_SHOW_PETS"] = "始终显示宠物"
+L["OPTIONS_ALWAYS_SHOW_KEYS"] = "始终显示钥匙"
+L["OPTIONS_ALWAYS_SHOW_BAGS"] = "始终显示背包"
+L["OPTIONS_ALWAYS_SHOW_CONTAINERS"] = "始终显示容器"
+L["OPTIONS_ALWAYS_SHOW_MONEY"] = "始终显示金钱"
+L["OPTIONS_LOOT_TOAST_MAX_ITEMS"] = "最多显示条数"
+L["OPTIONS_UNLIMITED"] = "不限"
+L["OPTIONS_LOOT_TOAST_DURATION"] = "屏幕显示秒数"
+L["OPTIONS_LOOT_TOAST_GROWTH"] = "增长方向"
+L["OPTIONS_GROW_UP"] = "向上"
+L["OPTIONS_GROW_DOWN"] = "向下"
+L["OPTIONS_LOOT_TOAST_ALIGN"] = "条目对齐"
+L["OPTIONS_ALIGN_LEFT"] = "左"
+L["OPTIONS_ALIGN_RIGHT"] = "右"
+L["OPTIONS_LOOT_TOAST_FONT"] = "字体"
+L["OPTIONS_FONT_DEFAULT"] = "默认"
+L["OPTIONS_LOOT_TOAST_FONT_SIZE"] = "字体大小"
+L["OPTIONS_LOOT_TOAST_OUTLINE"] = "字体描边"
+L["OPTIONS_FONT_OUTLINE_NONE"] = "无"
+L["OPTIONS_FONT_OUTLINE_OUTLINE"] = "描边"
+L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"] = "粗描边"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME"] = "单色"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"] = "单色描边"
+L["OPTIONS_TOASTS_UNLOCK"] = "解锁位置"
+L["OPTIONS_TOASTS_LOCK"] = "锁定位置"
+L["OPTIONS_TOASTS_RESET"] = "重置位置"
+L["OPTIONS_TOASTS_CLICK_DRAG"] = "点击 + 拖动以调整位置"
+L["OPTIONS_TOASTS_RIGHT_CLICK_LOCK"] = "右键点击以锁定"
+L["OPTIONS_TOASTS_DISABLE_BUTTON"] = "禁用拾取提示"
+L["OPTIONS_TOASTS_EXAMPLE_ITEM"] = "示例物品"
+
+-- Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
+L["OPTIONS_COMMAND"] = "/os"
+L["OPTIONS_COMMAND_DESCRIPTION"] = "打开此插件的选项界面。"
+
+-- Ignore List
+L["OPTIONS_IGNORE_LIST_DESCRIPTION"] =
+	"此列表中的物品不会被处理：快速拾取会把它们留在拾取窗口中，自动开启也永远不会打开它们。该列表由你的所有角色共享。"
+L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"] = "启用忽略列表通知"
+L["OPTIONS_IGNORE_LIST_ADD"] = "添加物品"
+L["OPTIONS_IGNORE_LIST_ADD_HINT"] = "把物品拖到这里，或粘贴物品链接或物品 ID。"
+L["OPTIONS_IGNORE_LIST_REMOVE"] = "从忽略列表中移除此物品。"
+L["OPTIONS_IGNORE_LIST_RESTORE"] = "恢复默认"
+L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"] = "要恢复默认忽略列表吗？你添加的物品将被移除。"
+L["OPTIONS_IGNORE_REASON_RAID"] =
+	"由团队首领掉落。未开启的容器仍可交易或出售，通常比里面的东西更值钱。"
+L["OPTIONS_IGNORE_REASON_QUEST"] =
+	"可能包含唯一的任务物品。如果你已经有一个，开启时可能会报错。"
+L["OPTIONS_IGNORE_REASON_RECIPE"] = "可能包含拾取后绑定的配方。未开启的容器仍可交易或出售。"
+L["OPTIONS_IGNORE_REASON_GEAR"] =
+	"可能包含拾取后绑定的武器或护甲。未开启的容器仍可交易或出售。"
+L["OPTIONS_IGNORE_REASON_HOLIDAY"] =
+	"可能包含拾取后绑定的节日物品。未开启的容器仍可交易或出售。"
+L["OPTIONS_IGNORE_REASON_ITEM"] = "可能包含拾取后绑定的物品。未开启的容器仍可交易或出售。"
+
+-- Feedback & Support
 L["OPTIONS_FEEDBACK"] = "反馈与支持"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"

--- a/Locales/zhTW.lua
+++ b/Locales/zhTW.lua
@@ -13,32 +13,48 @@ L["STATUS_DISABLED"] = "已停用"
 L["STATUS_PAUSED"] = "已暫停"
 
 --------------------------------------------------------------------------------
+-- Panel Tabs
+--------------------------------------------------------------------------------
+
+L["TAB_NOTIFICATIONS"] = "通知"
+L["TAB_LOCKBOXES"] = "鎖箱"
+L["TAB_IGNORE_LIST"] = "忽略清單"
+
+--------------------------------------------------------------------------------
 -- Chat Messages
 --------------------------------------------------------------------------------
 
 -- System
-L["AUTO_LOOT_ENABLED"] = "自動拾取已啟用。Open Sesame 需要它才能正常運作。"
+L["AUTO_LOOT_ENABLED"] = "自動拾取已啟用。Open Sesame 需要它才能運作。"
+L["CHAT_OPTIONS_IN_COMBAT"] = "基於安全考量，戰鬥中無法開啟選項介面。"
 L["CHAT_LOADED"] =
-	"版本 %s。設定（包括停用此訊息的選項）可以在 選項 > 插件 > Open Sesame 中找到。喜歡這個插件嗎？告訴你的朋友吧！(="
+	"版本 %s。設定（包括關閉此訊息的選項）位於 選項 > 插件 > Open Sesame。喜歡這個插件嗎？告訴朋友吧！(="
 
 -- Auto-Opening
-L["PAUSED_BAG_SLOTS"] = "自動開啟已暫停，直到背包有至少 %d 個空位。"
+L["PAUSED_BAG_SLOTS"] = "自動開啟已暫停，直到你有至少 %d 個空背包格。"
 L["RESUMED"] = "自動開啟已恢復。"
 L["INVENTORY_FULL"] = "背包已滿！"
-L["ITEM_WILL_AUTO_OPEN"] = "%s 將在解鎖後自動開啟。"
-L["ITEM_OPEN_MANUALLY"] =
-	"%s 需要手動開啟。它可能包含唯一、拾取綁定或暫時物品，或者是從團隊首領處獲得的。"
+L["ITEM_WILL_AUTO_OPEN"] = "%s 解鎖後將自動開啟。"
+L["ITEM_IGNORED"] = "%s 在你的忽略清單中，自動開啟沒有碰它。"
+L["ITEM_OPEN_MANUALLY"] = "%s 已留在拾取視窗中，供你自行開啟。"
 
 --------------------------------------------------------------------------------
 -- Features
 --------------------------------------------------------------------------------
 
 L["AUTO_OPENING"] = "自動開啟"
-L["AUTO_OPENING_DESC"] = "當背包有至少 %d 個空位時，自動開啟蛤蜊和已解鎖的容器。"
+L["AUTO_OPENING_DESCRIPTION"] = "當你有至少 %d 個空背包格時，自動開啟蚌殼和未上鎖的容器。"
 L["SPEEDY_LOOT"] = "快速拾取"
-L["SPEEDY_LOOT_DESC"] = "隱藏拾取視窗以實現近乎即時的拾取。"
+L["SPEEDY_LOOT_DESCRIPTION"] = "隱藏拾取視窗，讓拾取幾乎瞬間完成。"
+L["NOTIFICATIONS_DESCRIPTION"] =
+	"快速拾取會隱藏拾取視窗，因此 Open Sesame 透過這些方式告訴你剛剛撿到了什麼。"
+L["LOCKBOXES_DESCRIPTION"] =
+	"上鎖的容器需要盜賊的開鎖技能才能打開。這些選項會顯示每個鎖箱的需求，並在有鎖箱等待時提醒你。"
 L["LOOT_SOUNDS"] = "拾取音效"
-L["LOOT_SOUNDS_DESC"] = "拾取到優秀或更高品質的物品時播放特殊音效。"
+L["LOOT_SOUNDS_DESCRIPTION"] = "根據你選擇的品質設定播放音效。"
+L["LOOT_TOASTS"] = "拾取提示"
+L["LOOT_TOASTS_DESCRIPTION"] =
+	"由於快速拾取隱藏了拾取視窗，這會為你拾取的物品在螢幕上顯示簡短提示。把拾取記錄移出聊天視窗，可以讓視窗留給對話和真正重要的訊息。"
 
 --------------------------------------------------------------------------------
 -- Tooltip
@@ -50,25 +66,110 @@ L["KEYBIND_MIDDLE_CLICK"] = "中鍵點擊"
 L["KEYBIND_SHIFT_MIDDLE_CLICK"] = "Shift + 中鍵點擊"
 L["ACTION_TOGGLE"] = "切換"
 L["TOOLTIP_OPTIONS_TITLE"] = "Open Sesame 選項"
+L["TOOLTIP_REQUIRES_LOCKPICKING_LABEL"] = "需要開鎖"
+L["TOOLTIP_YOUR_LOCKPICKING_LABEL"] = "你的開鎖"
+L["TOOLTIP_LOCKED_ITEMS"] = "上鎖的物品"
 
 --------------------------------------------------------------------------------
 -- Options
 --------------------------------------------------------------------------------
 
-L["OPTIONS_INTRO"] =
-	"Open Sesame 自動開啟背包中的蛤蜊、保險箱和已解鎖的容器。內建的快速拾取功能會隱藏拾取視窗，實現近乎即時的拾取。少點點擊，多點遊戲。"
+-- General Panel
+L["OPTIONS_DESCRIPTION"] =
+	"自動開啟背包中的蚌殼、鎖箱和未上鎖的容器，無需點擊。內建的快速拾取會隱藏拾取視窗，讓自動拾取幾乎瞬間完成。少點滑鼠，多玩遊戲。"
 L["OPTIONS_ENABLE_WELCOME"] = "啟用歡迎訊息"
 L["OPTIONS_ENABLE_MINIMAP"] = "啟用小地圖按鈕"
-L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "啟用保險箱通知"
+
+-- Auto-Opening
 L["OPTIONS_ENABLE_AUTO_OPENING"] = "啟用自動開啟"
+L["OPTIONS_AUTO_OPENING_WHERE"] = "地點"
+L["OPTIONS_ANYWHERE"] = "任何地點"
+L["OPTIONS_OUTSIDE_INSTANCES"] = "副本之外"
+L["OPTIONS_AUTO_OPENING_GROUP"] = "隊伍"
+L["OPTIONS_SOLO_OR_GROUPED"] = "單人或組隊"
+L["OPTIONS_SOLO_ONLY"] = "僅單人"
+
+-- Speedy Loot
 L["OPTIONS_ENABLE_SPEEDY_LOOT"] = "啟用快速拾取"
+
+-- Lockboxes
+L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"] = "啟用鎖箱提示資訊"
+L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"] = "啟用鎖箱通知"
+L["OPTIONS_SHOW_FOR"] = "顯示對象"
+L["OPTIONS_FOR_ROGUES"] = "僅盜賊"
+L["OPTIONS_FOR_ALL_CHARACTERS"] = "所有角色"
+
+-- Notifications
 L["OPTIONS_ENABLE_LOOT_SOUNDS"] = "啟用拾取音效"
-L["OPTIONS_LOOT_SOUND_THRESHOLD"] = "拾取音效的最低品質"
 L["OPTIONS_TEST_LOOT_SOUND"] = "播放拾取音效。"
-L["OPTIONS_COMMANDS_HEADER"] = "/指令"
-L["OPTIONS_CMD_OS"] = "/os"
-L["OPTIONS_CMD_OS_DESCRIPTION"] = "開啟 Open Sesame 選項介面。"
-L["OPTIONS_FEEDBACK"] = "回饋與支援"
+L["OPTIONS_ENABLE_PICK_POCKET_SOUND"] = "啟用偷竊音效"
+L["OPTIONS_MINIMUM_QUALITY"] = "最低品質"
+
+-- Loot Toasts
+L["OPTIONS_ENABLE_LOOT_TOASTS"] = "啟用拾取提示"
+-- The threshold bypasses, then the money row, in the order the panel lists them.
+L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"] = "一律顯示拾取後綁定的物品"
+L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"] = "一律顯示任務物品"
+L["OPTIONS_ALWAYS_SHOW_RECIPES"] = "一律顯示配方"
+L["OPTIONS_ALWAYS_SHOW_MOUNTS"] = "一律顯示坐騎"
+L["OPTIONS_ALWAYS_SHOW_PETS"] = "一律顯示寵物"
+L["OPTIONS_ALWAYS_SHOW_KEYS"] = "一律顯示鑰匙"
+L["OPTIONS_ALWAYS_SHOW_BAGS"] = "一律顯示背包"
+L["OPTIONS_ALWAYS_SHOW_CONTAINERS"] = "一律顯示容器"
+L["OPTIONS_ALWAYS_SHOW_MONEY"] = "一律顯示金錢"
+L["OPTIONS_LOOT_TOAST_MAX_ITEMS"] = "最多顯示筆數"
+L["OPTIONS_UNLIMITED"] = "不限"
+L["OPTIONS_LOOT_TOAST_DURATION"] = "螢幕顯示秒數"
+L["OPTIONS_LOOT_TOAST_GROWTH"] = "增長方向"
+L["OPTIONS_GROW_UP"] = "向上"
+L["OPTIONS_GROW_DOWN"] = "向下"
+L["OPTIONS_LOOT_TOAST_ALIGN"] = "項目對齊"
+L["OPTIONS_ALIGN_LEFT"] = "左"
+L["OPTIONS_ALIGN_RIGHT"] = "右"
+L["OPTIONS_LOOT_TOAST_FONT"] = "字型"
+L["OPTIONS_FONT_DEFAULT"] = "預設"
+L["OPTIONS_LOOT_TOAST_FONT_SIZE"] = "字型大小"
+L["OPTIONS_LOOT_TOAST_OUTLINE"] = "字型外框"
+L["OPTIONS_FONT_OUTLINE_NONE"] = "無"
+L["OPTIONS_FONT_OUTLINE_OUTLINE"] = "外框"
+L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"] = "粗外框"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME"] = "單色"
+L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"] = "單色外框"
+L["OPTIONS_TOASTS_UNLOCK"] = "解鎖位置"
+L["OPTIONS_TOASTS_LOCK"] = "鎖定位置"
+L["OPTIONS_TOASTS_RESET"] = "重設位置"
+L["OPTIONS_TOASTS_CLICK_DRAG"] = "點擊 + 拖曳以調整位置"
+L["OPTIONS_TOASTS_RIGHT_CLICK_LOCK"] = "右鍵點擊以鎖定"
+L["OPTIONS_TOASTS_DISABLE_BUTTON"] = "停用拾取提示"
+L["OPTIONS_TOASTS_EXAMPLE_ITEM"] = "範例物品"
+
+-- Commands
+L["OPTIONS_COMMANDS_HEADER"] = "/Commands"
+L["OPTIONS_COMMAND"] = "/os"
+L["OPTIONS_COMMAND_DESCRIPTION"] = "開啟此插件的選項介面。"
+
+-- Ignore List
+L["OPTIONS_IGNORE_LIST_DESCRIPTION"] =
+	"此清單中的物品不會被處理：快速拾取會把它們留在拾取視窗中，自動開啟也永遠不會打開它們。該清單由你的所有角色共用。"
+L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"] = "啟用忽略清單通知"
+L["OPTIONS_IGNORE_LIST_ADD"] = "新增物品"
+L["OPTIONS_IGNORE_LIST_ADD_HINT"] = "把物品拖到這裡，或貼上物品連結或物品 ID。"
+L["OPTIONS_IGNORE_LIST_REMOVE"] = "從忽略清單中移除此物品。"
+L["OPTIONS_IGNORE_LIST_RESTORE"] = "恢復預設"
+L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"] = "要恢復預設忽略清單嗎？你新增的物品將被移除。"
+L["OPTIONS_IGNORE_REASON_RAID"] =
+	"由團隊首領掉落。未開啟的容器仍可交易或出售，通常比裡面的東西更值錢。"
+L["OPTIONS_IGNORE_REASON_QUEST"] =
+	"可能包含唯一的任務物品。如果你已經有一個，開啟時可能會出錯。"
+L["OPTIONS_IGNORE_REASON_RECIPE"] = "可能包含拾取後綁定的配方。未開啟的容器仍可交易或出售。"
+L["OPTIONS_IGNORE_REASON_GEAR"] =
+	"可能包含拾取後綁定的武器或護甲。未開啟的容器仍可交易或出售。"
+L["OPTIONS_IGNORE_REASON_HOLIDAY"] =
+	"可能包含拾取後綁定的節日物品。未開啟的容器仍可交易或出售。"
+L["OPTIONS_IGNORE_REASON_ITEM"] = "可能包含拾取後綁定的物品。未開啟的容器仍可交易或出售。"
+
+-- Feedback & Support
+L["OPTIONS_FEEDBACK"] = "意見回饋與支援"
 L["OPTIONS_CURSEFORGE"] = "CurseForge"
 L["OPTIONS_GITHUB"] = "GitHub"
 L["OPTIONS_DISCORD"] = "Discord"

--- a/Open-Sesame.toc
+++ b/Open-Sesame.toc
@@ -1,5 +1,5 @@
 ## Title: Open Sesame
-## Notes: Automatically open clams, lockboxes, and unlocked containers in your bags, no clicking required. Built-in Speedy Loot hides the loot window for near-instant auto looting. Less time clicking, more time playing.
+## Notes: Automatically open clams and unlocked containers in your bags, no clicking required. Built-in Speedy Loot hides the loot window for near-instant auto looting, and Loot Toasts show every pickup so your eyes stay on the fight. Fast, efficient looting.
 ## Author: Gogo1951
 
 ## IconTexture: Interface/AddOns/Open-Sesame/Includes/Images/Open-Sesame.tga
@@ -27,6 +27,7 @@
 # Includes
 Includes/Libraries/LibStub/LibStub.lua
 Includes/Libraries/CallbackHandler-1.0/CallbackHandler-1.0.lua
+Includes/Libraries/LibSharedMedia-3.0/LibSharedMedia-3.0.lua
 Includes/Libraries/AceLocale-3.0/AceLocale-3.0.lua
 Includes/Libraries/AceDB-3.0/AceDB-3.0.lua
 Includes/Libraries/AceGUI-3.0/AceGUI-3.0.xml
@@ -54,18 +55,25 @@ Locales/zhTW.lua
 # Data
 Data/Data.lua
 Data/Default-Settings.lua
+Data/Openable-Items.lua
 
 # Open Sesame
 Features/Core.lua
 Features/Utilities.lua
 Features/Announcements.lua
+Features/Ignore-List.lua
 Features/Speedy-Loot.lua
+Features/Lockbox-Tooltips.lua
+Features/Loot-Toasts.lua
 Features/Diagnostics.lua
 Features/Minimap-Button.lua
 
 # Options
 Options/Options-Utilities.lua
 Options/Options-General.lua
+Options/Options-Notifications.lua
+Options/Options-Lockboxes.lua
+Options/Options-Ignore-List.lua
 Options/Options-Profiles.lua
 Options/Options-Diagnostics.lua
 Options/Options.lua

--- a/Options/Options-Diagnostics.lua
+++ b/Options/Options-Diagnostics.lua
@@ -10,9 +10,10 @@ local AceConfigRegistry = LibStub("AceConfigRegistry-3.0")
 
 --[[
     A single runtime toggle gates the whole panel. When off, only the warning
-    text and the enable toggle are visible; everything below is hidden. The
-    OptionsHeader / OptionsSpacer helpers do not support `hidden`, so the
-    gated sections inline their header widgets with `hidden` functions.
+    text and the enable toggle are visible; everything below is hidden. Every
+    gated section hides on that one condition, so the panel defines local
+    SectionHeader / ReportOutput builders that bake it in alongside the shared
+    Hidden and Refresh locals, rather than repeating the predicate per widget.
 ]]
 
 local function DiagnosticsOn()
@@ -102,7 +103,7 @@ function ns.BuildDiagnosticsOptions()
 			outputEventLog = ReportOutput("eventLogReport", 9),
 			descEventLogHint = {
 				type = "description",
-				name = GetColor("BODY") .. D.EVENT_LOG_HINT .. "|r",
+				name = GetColor("HELP") .. D.EVENT_LOG_HINT .. "|r",
 				fontSize = "medium",
 				order = 10,
 				hidden = Hidden,
@@ -163,6 +164,34 @@ function ns.BuildDiagnosticsOptions()
 				end,
 			},
 			outputAddons = ReportOutput("addOnReport", 32),
+
+			-- Relevant CVars
+			headerCVars = SectionHeader(D.CVARS_TITLE, 33),
+			buttonCVars = {
+				type = "execute",
+				name = D.CVARS_BUTTON,
+				order = 34,
+				hidden = Hidden,
+				func = function()
+					ns.diagnostics.cvarReport = ns:BuildCVarReport()
+					Refresh()
+				end,
+			},
+			outputCVars = ReportOutput("cvarReport", 35),
+
+			-- Display Context
+			headerDisplay = SectionHeader(D.DISPLAY_TITLE, 36),
+			buttonDisplay = {
+				type = "execute",
+				name = D.DISPLAY_BUTTON,
+				order = 37,
+				hidden = Hidden,
+				func = function()
+					ns.diagnostics.displayReport = ns:BuildDisplayReport()
+					Refresh()
+				end,
+			},
+			outputDisplay = ReportOutput("displayReport", 38),
 
 			-- Saved Variables
 			headerSaved = SectionHeader(D.SAVED_TITLE, 40),
@@ -225,7 +254,7 @@ function ns.BuildDiagnosticsOptions()
 			},
 			descTaintHint = {
 				type = "description",
-				name = GetColor("BODY") .. D.TAINT_HINT .. "|r",
+				name = GetColor("HELP") .. D.TAINT_HINT .. "|r",
 				fontSize = "medium",
 				order = 64,
 				hidden = Hidden,

--- a/Options/Options-General.lua
+++ b/Options/Options-General.lua
@@ -3,6 +3,20 @@ local _, ns = ...
 local L = ns.L
 local GetColor = ns.GetColor
 
+--[[
+    The four link rows split ns.OPTIONS_ROW_WIDTH unevenly: their labels are one
+    short word, while the box beside them holds a full URL the player is meant to
+    select and copy. The label takes 0.6 so the box lands on exactly 2.0, the
+    guide's double width for a read-only URL input, without the row outgrowing
+    every other row on the panel. Same split Magic Eraser uses.
+]]
+local LINK_LABEL_WIDTH = 0.6
+local LINK_URL_WIDTH = ns.OPTIONS_ROW_WIDTH - LINK_LABEL_WIDTH
+
+local function IsAutoOpenDisabled()
+	return not ns.db.profile.autoOpen
+end
+
 --------------------------------------------------------------------------------
 -- Options Table
 --------------------------------------------------------------------------------
@@ -12,7 +26,7 @@ function ns.BuildGeneralOptions()
 		name = L["ADDON_TITLE"],
 		type = "group",
 		args = {
-			descIntro = ns.OptionsDesc(L["OPTIONS_INTRO"], 1),
+			descIntro = ns.OptionsDesc(L["OPTIONS_DESCRIPTION"], 1),
 			-- Welcome Message
 
 			spaceWelcome0 = ns.OptionsSpacer(5),
@@ -34,7 +48,7 @@ function ns.BuildGeneralOptions()
 				order = 7,
 				width = "full",
 				get = function()
-					return ns.db and not ns.db.global.minimap.hide
+					return ns.db and not ns.db.profile.minimap.hide
 				end,
 				set = function(_, value)
 					ns:SetMinimapShown(value)
@@ -46,7 +60,7 @@ function ns.BuildGeneralOptions()
 			headerCommands = ns.OptionsHeader(L["OPTIONS_COMMANDS_HEADER"], 11),
 			spaceCommands1 = ns.OptionsSpacer(12),
 			descCommands = ns.OptionsDesc(
-				GetColor("INFO") .. L["OPTIONS_CMD_OS"] .. "|r" .. "  " .. L["OPTIONS_CMD_OS_DESCRIPTION"],
+				GetColor("INFO") .. L["OPTIONS_COMMAND"] .. "|r" .. "  " .. L["OPTIONS_COMMAND_DESCRIPTION"],
 				13
 			),
 			-- Auto-Opening
@@ -54,7 +68,7 @@ function ns.BuildGeneralOptions()
 			spaceAutoOpen0 = ns.OptionsSpacer(20),
 			headerAutoOpen = ns.OptionsHeader(L["AUTO_OPENING"], 21),
 			spaceAutoOpen1 = ns.OptionsSpacer(22),
-			descAutoOpen = ns.OptionsDesc(string.format(L["AUTO_OPENING_DESC"], ns.MIN_FREE_SLOTS), 23),
+			descAutoOpen = ns.OptionsDesc(string.format(L["AUTO_OPENING_DESCRIPTION"], ns.MIN_FREE_SLOTS), 23),
 			spaceAutoOpen2 = ns.OptionsSpacer(24),
 			toggleAutoOpen = {
 				type = "toggle",
@@ -74,27 +88,42 @@ function ns.BuildGeneralOptions()
 					ns:UpdateMinimapIcon()
 				end,
 			},
-			toggleLockboxNotifications = {
-				type = "toggle",
-				name = L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"],
-				order = 26,
-				width = "full",
-				hidden = function()
-					return not ns.db.profile.autoOpen
-				end,
+			subAutoOpenWhere = ns.OptionsSubSelectRow(26, IsAutoOpenDisabled, L["OPTIONS_AUTO_OPENING_WHERE"], {
+				type = "select",
+				values = {
+					ALWAYS = L["OPTIONS_ANYWHERE"],
+					OUTSIDE_INSTANCES = L["OPTIONS_OUTSIDE_INSTANCES"],
+				},
+				sorting = { "ALWAYS", "OUTSIDE_INSTANCES" },
 				get = function()
-					return ns.db.profile.lockboxNotifications
+					return ns.db.profile.autoOpenWhere
 				end,
 				set = function(_, value)
-					ns.db.profile.lockboxNotifications = value
+					ns.db.profile.autoOpenWhere = value
+					ns.ScheduleScan(true)
 				end,
-			},
+			}),
+			subAutoOpenGroup = ns.OptionsSubSelectRow(27, IsAutoOpenDisabled, L["OPTIONS_AUTO_OPENING_GROUP"], {
+				type = "select",
+				values = {
+					ALWAYS = L["OPTIONS_SOLO_OR_GROUPED"],
+					SOLO_ONLY = L["OPTIONS_SOLO_ONLY"],
+				},
+				sorting = { "ALWAYS", "SOLO_ONLY" },
+				get = function()
+					return ns.db.profile.autoOpenGroup
+				end,
+				set = function(_, value)
+					ns.db.profile.autoOpenGroup = value
+					ns.ScheduleScan(true)
+				end,
+			}),
 			-- Speedy Loot
 
 			spaceSpeedyLoot0 = ns.OptionsSpacer(30),
 			headerSpeedyLoot = ns.OptionsHeader(L["SPEEDY_LOOT"], 31),
 			spaceSpeedyLoot1 = ns.OptionsSpacer(32),
-			descSpeedyLoot = ns.OptionsDesc(L["SPEEDY_LOOT_DESC"], 33),
+			descSpeedyLoot = ns.OptionsDesc(L["SPEEDY_LOOT_DESCRIPTION"], 33),
 			spaceSpeedyLoot2 = ns.OptionsSpacer(34),
 			toggleSpeedyLoot = {
 				type = "toggle",
@@ -113,123 +142,57 @@ function ns.BuildGeneralOptions()
 					ns:UpdateMinimapIcon()
 				end,
 			},
-			-- Loot Sounds
-
-			spaceLootSounds0 = ns.OptionsSpacer(40),
-			headerLootSounds = ns.OptionsHeader(L["LOOT_SOUNDS"], 41),
-			spaceLootSounds1 = ns.OptionsSpacer(42),
-			descLootSounds = ns.OptionsDesc(L["LOOT_SOUNDS_DESC"], 43),
-			spaceLootSounds2 = ns.OptionsSpacer(44),
-			toggleLootSounds = {
-				type = "toggle",
-				name = L["OPTIONS_ENABLE_LOOT_SOUNDS"],
-				order = 45,
-				width = "normal",
-				get = function()
-					return ns.db.profile.lootSounds
-				end,
-				set = function(_, value)
-					ns.db.profile.lootSounds = value
-				end,
-			},
-			--[[
-				    The quality dropdown and the preview speaker share the loot sound row
-				    with the toggle: toggle (45), dropdown (47), speaker (48). Tier labels
-				    use the client-localized ITEM_QUALITYn_DESC globals wrapped in the
-				    game's own item-quality colors, so the dropdown reads green/blue/purple
-				    like the items themselves — no locale keys needed for the tier names.
-				    sorting forces numeric 2/3/4 order.
-				]]
-			selectLootSoundThreshold = {
-				type = "select",
-				name = L["OPTIONS_LOOT_SOUND_THRESHOLD"],
-				order = 47,
-				width = "normal",
-				values = {
-					[2] = ITEM_QUALITY_COLORS[2].hex .. ITEM_QUALITY2_DESC .. "|r",
-					[3] = ITEM_QUALITY_COLORS[3].hex .. ITEM_QUALITY3_DESC .. "|r",
-					[4] = ITEM_QUALITY_COLORS[4].hex .. ITEM_QUALITY4_DESC .. "|r",
-				},
-				sorting = { 2, 3, 4 },
-				disabled = function()
-					return not ns.db.profile.lootSounds
-				end,
-				get = function()
-					return ns.db.profile.lootSoundThreshold
-				end,
-				set = function(_, value)
-					ns.db.profile.lootSoundThreshold = value
-				end,
-			},
-			--[[
-				    Speaker icon just right of the dropdown that previews the actual loot
-				    sound (ns.LOOT_SOUND_FILE, the same file Core plays on a rare drop) so
-				    the player can hear it before enabling. The Icon widget centers its
-				    image in the control, so a narrow width (0.2 grid units) keeps the
-				    speaker tight against the dropdown instead of floating in a wide cell.
-				    order 48 places it right after the dropdown (47). Always clickable — a
-				    preview, independent of whether Loot Sound is on.
-				]]
-			playLootSound = {
-				type = "execute",
-				name = "",
-				desc = L["OPTIONS_TEST_LOOT_SOUND"],
-				order = 48,
-				width = 0.2,
-				image = "Interface\\COMMON\\VoiceChat-Speaker",
-				imageWidth = 24,
-				imageHeight = 24,
-				func = function()
-					PlaySoundFile(ns.LOOT_SOUND_FILE, "Master")
-				end,
-			},
 			-- Feedback & Support
 
 			spaceCommunity0 = ns.OptionsSpacer(90),
 			headerCommunity = ns.OptionsHeader(L["OPTIONS_FEEDBACK"], 91),
 			spaceCommunity1 = ns.OptionsSpacer(92),
-			discordLabel = ns.OptionsDesc(GetColor("TITLE") .. L["OPTIONS_DISCORD"] .. "|r", 93),
+			discordLabel = ns.OptionsRowLabel(GetColor("TITLE") .. L["OPTIONS_DISCORD"] .. "|r", 93, LINK_LABEL_WIDTH),
 			discordURL = {
 				type = "input",
 				name = "",
 				order = 94,
-				width = "double",
+				width = LINK_URL_WIDTH,
 				get = function()
 					return ns.DISCORD_URL
 				end,
 				set = function() end,
 			},
 			spaceCommunity2 = ns.OptionsSpacer(95),
-			githubLabel = ns.OptionsDesc(GetColor("TITLE") .. L["OPTIONS_GITHUB"] .. "|r", 96),
+			githubLabel = ns.OptionsRowLabel(GetColor("TITLE") .. L["OPTIONS_GITHUB"] .. "|r", 96, LINK_LABEL_WIDTH),
 			githubURL = {
 				type = "input",
 				name = "",
 				order = 97,
-				width = "double",
+				width = LINK_URL_WIDTH,
 				get = function()
 					return ns.GITHUB_URL
 				end,
 				set = function() end,
 			},
 			spaceCommunity3 = ns.OptionsSpacer(98),
-			curseforgeLabel = ns.OptionsDesc(GetColor("TITLE") .. L["OPTIONS_CURSEFORGE"] .. "|r", 99),
+			curseforgeLabel = ns.OptionsRowLabel(
+				GetColor("TITLE") .. L["OPTIONS_CURSEFORGE"] .. "|r",
+				99,
+				LINK_LABEL_WIDTH
+			),
 			curseforgeURL = {
 				type = "input",
 				name = "",
 				order = 100,
-				width = "double",
+				width = LINK_URL_WIDTH,
 				get = function()
 					return ns.CURSEFORGE_URL
 				end,
 				set = function() end,
 			},
 			spaceCommunity4 = ns.OptionsSpacer(101),
-			wagoLabel = ns.OptionsDesc(GetColor("TITLE") .. L["OPTIONS_WAGO"] .. "|r", 102),
+			wagoLabel = ns.OptionsRowLabel(GetColor("TITLE") .. L["OPTIONS_WAGO"] .. "|r", 102, LINK_LABEL_WIDTH),
 			wagoURL = {
 				type = "input",
 				name = "",
 				order = 103,
-				width = "double",
+				width = LINK_URL_WIDTH,
 				get = function()
 					return ns.WAGO_URL
 				end,

--- a/Options/Options-Ignore-List.lua
+++ b/Options/Options-Ignore-List.lua
@@ -1,0 +1,63 @@
+local _, ns = ...
+
+local L = ns.L
+
+--------------------------------------------------------------------------------
+-- Ignore List Panel
+--------------------------------------------------------------------------------
+
+--[[
+    Shape, order, and widths all come from ns:BuildItemListOptions in
+    Options-Utilities.lua; this file supplies only the copy, the source table,
+    and the callbacks. The list ships defaults, so it carries a Restore Defaults
+    row.
+]]
+
+function ns.BuildIgnoreListOptions()
+	local args = ns:BuildItemListOptions({
+		registryName = ns.OPTIONS_REGISTRY.IgnoreList,
+		startOrder = 10,
+		source = ns:GetIgnoreList(),
+		-- Why a shipped row is on the list; nil for anything the player added.
+		noteFor = function(itemId)
+			return ns:GetIgnoreNote(itemId)
+		end,
+		addLabel = L["OPTIONS_IGNORE_LIST_ADD"],
+		addHint = L["OPTIONS_IGNORE_LIST_ADD_HINT"],
+		removeLabel = L["OPTIONS_IGNORE_LIST_REMOVE"],
+		restoreLabel = L["OPTIONS_IGNORE_LIST_RESTORE"],
+		restoreConfirm = L["OPTIONS_IGNORE_LIST_RESTORE_CONFIRM"],
+		onAdd = function(itemId)
+			ns:AddIgnoredItem(itemId)
+		end,
+		onRemove = function(itemId)
+			ns:RemoveIgnoredItem(itemId)
+		end,
+		onRestore = function()
+			ns:RestoreDefaultIgnoreList()
+		end,
+	})
+
+	-- The list starts at 10, leaving 1-9 for the panel's own copy and controls.
+	args.descIgnoreList = ns.OptionsDesc(L["OPTIONS_IGNORE_LIST_DESCRIPTION"], 1)
+	args.spaceIgnoreList0 = ns.OptionsSpacer(2)
+	args.toggleIgnoreListNotifications = {
+		type = "toggle",
+		name = L["OPTIONS_ENABLE_IGNORE_LIST_NOTIFICATIONS"],
+		order = 3,
+		width = "full",
+		get = function()
+			return ns.db.profile.ignoreListNotifications
+		end,
+		set = function(_, value)
+			ns.db.profile.ignoreListNotifications = value
+		end,
+	}
+	args.spaceIgnoreList1 = ns.OptionsSpacer(4)
+
+	return {
+		type = "group",
+		name = L["TAB_IGNORE_LIST"],
+		args = args,
+	}
+end

--- a/Options/Options-Lockboxes.lua
+++ b/Options/Options-Lockboxes.lua
@@ -1,0 +1,96 @@
+local _, ns = ...
+
+local L = ns.L
+
+--------------------------------------------------------------------------------
+-- Lockboxes Panel
+--------------------------------------------------------------------------------
+
+--[[
+    Everything the add-on does about locked containers: what a lockbox needs, and
+    when it says so.
+
+    Both features carry a scope beside their toggle rather than only an on/off,
+    because a non-Rogue cannot pick a lock and has little use for either. The
+    predicates behind the scopes live in Features/Utilities.lua, shared with Core
+    and Speedy-Loot.
+]]
+
+local function TooltipsOff()
+	return not ns.db.profile.lockboxTooltips
+end
+
+local function NotificationsOff()
+	return not ns.db.profile.lockboxNotifications
+end
+
+local function ScopeControl(get, set)
+	return {
+		type = "select",
+		values = {
+			ROGUES = L["OPTIONS_FOR_ROGUES"],
+			ALL = L["OPTIONS_FOR_ALL_CHARACTERS"],
+		},
+		sorting = { "ROGUES", "ALL" },
+		get = get,
+		set = set,
+	}
+end
+
+function ns.BuildLockboxesOptions()
+	return {
+		name = L["TAB_LOCKBOXES"],
+		type = "group",
+		args = {
+			descLockboxes = ns.OptionsDesc(L["LOCKBOXES_DESCRIPTION"], 1),
+			spaceIntro = ns.OptionsSpacer(2),
+
+			toggleLockboxTooltips = {
+				type = "toggle",
+				name = L["OPTIONS_ENABLE_LOCKBOX_TOOLTIPS"],
+				order = 10,
+				width = "full",
+				get = function()
+					return ns.db.profile.lockboxTooltips
+				end,
+				set = function(_, value)
+					ns.db.profile.lockboxTooltips = value
+				end,
+			},
+			subTooltipsScope = ns.OptionsSubSelectRow(
+				11,
+				TooltipsOff,
+				L["OPTIONS_SHOW_FOR"],
+				ScopeControl(function()
+					return ns.db.profile.lockboxTooltipsScope
+				end, function(_, value)
+					ns.db.profile.lockboxTooltipsScope = value
+				end)
+			),
+
+			spaceNotifications = ns.OptionsSpacer(20),
+			toggleLockboxNotifications = {
+				type = "toggle",
+				name = L["OPTIONS_ENABLE_LOCKBOX_NOTIFICATIONS"],
+				order = 21,
+				width = "full",
+				get = function()
+					return ns.db.profile.lockboxNotifications
+				end,
+				set = function(_, value)
+					ns.db.profile.lockboxNotifications = value
+				end,
+			},
+			subNotificationsScope = ns.OptionsSubSelectRow(
+				22,
+				NotificationsOff,
+				L["OPTIONS_SHOW_FOR"],
+				ScopeControl(function()
+					return ns.db.profile.lockboxNotificationsScope
+				end, function(_, value)
+					ns.db.profile.lockboxNotificationsScope = value
+				end)
+			),
+		},
+	}
+end

--- a/Options/Options-Notifications.lua
+++ b/Options/Options-Notifications.lua
@@ -1,0 +1,444 @@
+local _, ns = ...
+
+local L = ns.L
+
+--------------------------------------------------------------------------------
+-- Notifications Panel
+--------------------------------------------------------------------------------
+
+--[[
+    The two ways the add-on tells the player what they just looted: a sound, and
+    an on-screen toast. Speedy Loot hides the loot window, so between them these
+    are the only record outside the chat log.
+]]
+
+-- The speaker preview's cell, sized to its icon rather than to a caption.
+local LOOT_SOUND_PREVIEW_WIDTH = 0.2
+
+--[[
+    This panel carries the add-on's longest sub-row captions ("Maximum Items to
+    Display"), which wrap to two lines at the shared sub-row label width. The
+    label takes the extra width and the control gives back exactly as much, so
+    the rows still total what every other sub-row totals and no other panel
+    changes. The dropdowns hold short values (a quality name, a bare number, a
+    direction), so the width comes off them for free.
+]]
+local SUB_LABEL_WIDTH = 1.4
+local SUB_CONTROL_WIDTH = 0.9
+
+--[[
+    The bypass checkboxes: sized to their captions, well clear of the wrap
+    boundary. Set by the longest of the six, "Always Show Bind on Pick-up Items",
+    and capped by the grid - a sub-row leads with a blank indent cell, so this
+    plus ns.OPTIONS_SUB_INDENT_WIDTH has to stay inside ns.OPTIONS_ROW_WIDTH.
+]]
+local BYPASS_TOGGLE_WIDTH = 2.4
+
+local function SubSelectRow(order, hidden, caption, control)
+	control.width = control.width or SUB_CONTROL_WIDTH
+	return ns.OptionsSubSelectRow(order, hidden, caption, control, SUB_LABEL_WIDTH)
+end
+
+-- The toast move/reset row: a blank label cell plus two equal buttons.
+local TOAST_BUTTON_WIDTH = 0.8
+local TOAST_LABEL_WIDTH = ns.OPTIONS_ROW_WIDTH - (TOAST_BUTTON_WIDTH * 2)
+
+local function LootSoundsOff()
+	return not ns.db.profile.lootSounds
+end
+
+local function LootToastsOff()
+	return not ns.db.profile.lootToasts
+end
+
+--[[
+    Every threshold-bypass row is the same shape - an indented checkbox reading one
+    boolean off the profile - so they are built from one helper. Hand-written
+    copies would be one chance per row for one to drift away from the rest. The
+    money row rides the same shape without being a threshold bypass.
+]]
+local function BypassRow(order, hidden, caption, key)
+	return ns.OptionsSubRow(order, hidden, {
+		{
+			type = "toggle",
+			name = ns.OptionsSubLabel(caption),
+			width = BYPASS_TOGGLE_WIDTH,
+			get = function()
+				return ns.db.profile[key]
+			end,
+			set = function(_, value)
+				ns.db.profile[key] = value
+			end,
+		},
+	})
+end
+
+--[[
+    Both quality dropdowns read the client-localized ITEM_QUALITYn_DESC globals,
+    wrapped in the game's own quality colours so each tier reads
+    grey/white/green/blue/purple like the items themselves. Built once so the two
+    cannot drift. Their defaults deliberately differ: the sound starts at Uncommon
+    because it is an interruption and wants to be rare, while toasts start at Poor
+    because the stack stands in for the loot window and wants to be complete. That
+    is also why the toast dropdown offers Poor and Common at all and the sound's
+    does not.
+]]
+local QUALITY_DESC = {
+	[0] = ITEM_QUALITY0_DESC,
+	[1] = ITEM_QUALITY1_DESC,
+	[2] = ITEM_QUALITY2_DESC,
+	[3] = ITEM_QUALITY3_DESC,
+	[4] = ITEM_QUALITY4_DESC,
+}
+
+local function QualityChoices(lowest)
+	local values, sorting = {}, {}
+	for quality = lowest, 4 do
+		values[quality] = ITEM_QUALITY_COLORS[quality].hex .. QUALITY_DESC[quality] .. "|r"
+		sorting[#sorting + 1] = quality
+	end
+	return values, sorting
+end
+
+local SOUND_QUALITY_VALUES, SOUND_QUALITY_SORTING = QualityChoices(2)
+local TOAST_QUALITY_VALUES, TOAST_QUALITY_SORTING = QualityChoices(0)
+
+-- Bare numbers, so no locale needs a singular/plural form for "second".
+local DURATION_VALUES = {}
+for _, seconds in ipairs(ns.LOOT_TOAST_DURATIONS) do
+	DURATION_VALUES[seconds] = tostring(seconds)
+end
+
+--[[
+    Same bare numbers, with Unlimited last. It sorts after 21 rather than before
+    1 because it belongs at the "more" end of the scale, which is where a player
+    reading the list downward will look for it.
+]]
+local COUNT_VALUES = { [ns.LOOT_TOAST_UNLIMITED] = L["OPTIONS_UNLIMITED"] }
+local COUNT_SORTING = {}
+for _, count in ipairs(ns.LOOT_TOAST_COUNTS) do
+	COUNT_VALUES[count] = tostring(count)
+	COUNT_SORTING[#COUNT_SORTING + 1] = count
+end
+COUNT_SORTING[#COUNT_SORTING + 1] = ns.LOOT_TOAST_UNLIMITED
+
+-- The client's own SetFont flag strings, captioned. Sorted by ns.LOOT_TOAST_FONT_FLAGS.
+local FONT_FLAG_LABELS = {
+	NONE = L["OPTIONS_FONT_OUTLINE_NONE"],
+	OUTLINE = L["OPTIONS_FONT_OUTLINE_OUTLINE"],
+	THICKOUTLINE = L["OPTIONS_FONT_OUTLINE_THICK_OUTLINE"],
+	MONOCHROME = L["OPTIONS_FONT_OUTLINE_MONOCHROME"],
+	MONOCHROMEOUTLINE = L["OPTIONS_FONT_OUTLINE_MONOCHROME_OUTLINE"],
+}
+
+local FONT_FLAG_VALUES = {}
+for _, flag in ipairs(ns.LOOT_TOAST_FONT_FLAGS) do
+	FONT_FLAG_VALUES[flag] = FONT_FLAG_LABELS[flag]
+end
+
+function ns.BuildNotificationsOptions()
+	return {
+		name = L["TAB_NOTIFICATIONS"],
+		type = "group",
+		args = {
+			descNotifications = ns.OptionsDesc(L["NOTIFICATIONS_DESCRIPTION"], 1),
+			spaceIntro = ns.OptionsSpacer(2),
+
+			-- Loot Sound
+			headerLootSounds = ns.OptionsHeader(L["LOOT_SOUNDS"], 10),
+			spaceLootSounds0 = ns.OptionsSpacer(11),
+			descLootSounds = ns.OptionsDesc(L["LOOT_SOUNDS_DESCRIPTION"], 12),
+			spaceLootSounds1 = ns.OptionsSpacer(13),
+			toggleLootSounds = {
+				type = "toggle",
+				name = L["OPTIONS_ENABLE_LOOT_SOUNDS"],
+				order = 14,
+				width = "full",
+				get = function()
+					return ns.db.profile.lootSounds
+				end,
+				set = function(_, value)
+					ns.db.profile.lootSounds = value
+				end,
+			},
+			--[[
+                The threshold row carries the preview speaker as a third cell, so
+                it is built directly rather than through OptionsSubSelectRow.
+            ]]
+			subSoundQuality = ns.OptionsSubRow(15, LootSoundsOff, {
+				ns.OptionsRowLabel(ns.OptionsSubLabel(L["OPTIONS_MINIMUM_QUALITY"]), nil, SUB_LABEL_WIDTH),
+				{
+					type = "select",
+					name = "",
+					width = SUB_CONTROL_WIDTH - LOOT_SOUND_PREVIEW_WIDTH,
+					values = SOUND_QUALITY_VALUES,
+					sorting = SOUND_QUALITY_SORTING,
+					get = function()
+						return ns.db.profile.lootSoundThreshold
+					end,
+					set = function(_, value)
+						ns.db.profile.lootSoundThreshold = value
+					end,
+				},
+				{
+					type = "execute",
+					name = "",
+					desc = L["OPTIONS_TEST_LOOT_SOUND"],
+					width = LOOT_SOUND_PREVIEW_WIDTH,
+					image = "Interface\\COMMON\\VoiceChat-Speaker",
+					imageWidth = 24,
+					imageHeight = 24,
+					func = function()
+						PlaySoundFile(ns.LOOT_SOUND_FILE, "Master")
+					end,
+				},
+			}),
+			--[[
+                Its own toggle rather than a sub-option of the loot sound, because
+                it answers a different question. The loot sound reports what came
+                out of a corpse and is filtered by quality; this one reports that a
+                Pick Pocket landed at all, which is mostly coin - no quality, no
+                toast, and nothing in a loot window the player can still see.
+            ]]
+			spaceLootSounds2 = ns.OptionsSpacer(16),
+			togglePickPocketSound = {
+				type = "toggle",
+				name = L["OPTIONS_ENABLE_PICK_POCKET_SOUND"],
+				order = 17,
+				width = "full",
+				get = function()
+					return ns.db.profile.pickPocketSound
+				end,
+				set = function(_, value)
+					ns.db.profile.pickPocketSound = value
+				end,
+			},
+
+			-- Loot Toasts
+			spaceLootToasts0 = ns.OptionsSpacer(20),
+			headerLootToasts = ns.OptionsHeader(L["LOOT_TOASTS"], 21),
+			spaceLootToasts1 = ns.OptionsSpacer(22),
+			descLootToasts = ns.OptionsDesc(L["LOOT_TOASTS_DESCRIPTION"], 23),
+			spaceLootToasts2 = ns.OptionsSpacer(24),
+			toggleLootToasts = {
+				type = "toggle",
+				name = L["OPTIONS_ENABLE_LOOT_TOASTS"],
+				order = 25,
+				width = "full",
+				get = function()
+					return ns.db.profile.lootToasts
+				end,
+				set = function(_, value)
+					ns.SetLootToastsEnabled(value)
+				end,
+			},
+			subToastQuality = SubSelectRow(26, LootToastsOff, L["OPTIONS_MINIMUM_QUALITY"], {
+				type = "select",
+				values = TOAST_QUALITY_VALUES,
+				sorting = TOAST_QUALITY_SORTING,
+				get = function()
+					return ns.db.profile.lootToastThreshold
+				end,
+				set = function(_, value)
+					ns.db.profile.lootToastThreshold = value
+					ns.RefreshLootToastSamples()
+				end,
+			}),
+			--[[
+                Eight escape hatches from the threshold above, each an ordinary
+                sub-option of the feature toggle, followed by the money row, which
+                takes the same shape without being a threshold bypass: coin has no
+                quality to be measured against. Sized to their captions with room
+                to spare, per the guide's rule that a sub-row control on the wrap
+                boundary strands its own indent.
+
+                Ordered for the player reading down the list, not by anything the
+                code cares about. Bind on Pickup leads because it is the one rule
+                that answers "is this a keep?" on its own, and a player who leaves
+                it on may not need to think about the rest. The named kinds follow
+                in the order they matter to most characters, and the two storage
+                rows sit together at the end - Bags for what the player will carry
+                loot in, Containers for what Open Sesame is about to open, which is
+                the only row here that is about the add-on rather than the item.
+
+                Features/Loot-Toasts.lua evaluates them in a different order, by
+                what each costs to answer. The two orders are unrelated on purpose.
+            ]]
+			subToastBindOnPickup = BypassRow(
+				27,
+				LootToastsOff,
+				L["OPTIONS_ALWAYS_SHOW_BIND_ON_PICKUP"],
+				"lootToastBindOnPickup"
+			),
+			subToastQuestItems = BypassRow(
+				28,
+				LootToastsOff,
+				L["OPTIONS_ALWAYS_SHOW_QUEST_ITEMS"],
+				"lootToastQuestItems"
+			),
+			subToastRecipes = BypassRow(29, LootToastsOff, L["OPTIONS_ALWAYS_SHOW_RECIPES"], "lootToastRecipes"),
+			subToastMounts = BypassRow(30, LootToastsOff, L["OPTIONS_ALWAYS_SHOW_MOUNTS"], "lootToastMounts"),
+			subToastPets = BypassRow(31, LootToastsOff, L["OPTIONS_ALWAYS_SHOW_PETS"], "lootToastPets"),
+			subToastKeys = BypassRow(32, LootToastsOff, L["OPTIONS_ALWAYS_SHOW_KEYS"], "lootToastKeys"),
+			subToastBags = BypassRow(33, LootToastsOff, L["OPTIONS_ALWAYS_SHOW_BAGS"], "lootToastBags"),
+			subToastContainers = BypassRow(
+				34,
+				LootToastsOff,
+				L["OPTIONS_ALWAYS_SHOW_CONTAINERS"],
+				"lootToastContainers"
+			),
+			subToastMoney = BypassRow(35, LootToastsOff, L["OPTIONS_ALWAYS_SHOW_MONEY"], "lootToastMoney"),
+			subToastMaxItems = SubSelectRow(36, LootToastsOff, L["OPTIONS_LOOT_TOAST_MAX_ITEMS"], {
+				type = "select",
+				values = COUNT_VALUES,
+				sorting = COUNT_SORTING,
+				get = function()
+					return ns.db.profile.lootToastMaxVisible
+				end,
+				set = function(_, value)
+					ns.db.profile.lootToastMaxVisible = value
+					ns.ApplyLootToastLimit()
+				end,
+			}),
+			subToastDuration = SubSelectRow(37, LootToastsOff, L["OPTIONS_LOOT_TOAST_DURATION"], {
+				type = "select",
+				values = DURATION_VALUES,
+				sorting = ns.LOOT_TOAST_DURATIONS,
+				get = function()
+					return ns.db.profile.lootToastDuration
+				end,
+				set = function(_, value)
+					ns.db.profile.lootToastDuration = value
+					ns.RefreshLootToastSamples()
+				end,
+			}),
+			subToastFont = SubSelectRow(40, LootToastsOff, L["OPTIONS_LOOT_TOAST_FONT"], {
+				type = "select",
+				--[[
+                    Functions, not tables: the list depends on whether anything
+                    on this client has loaded LibSharedMedia, which is not known
+                    when this panel is built and can change between openings.
+                ]]
+				values = function()
+					return (ns.GetLootToastFontChoices())
+				end,
+				sorting = function()
+					local _, sorting = ns.GetLootToastFontChoices()
+					return sorting
+				end,
+				get = function()
+					return ns.db.profile.lootToastFont
+				end,
+				set = function(_, value)
+					ns.db.profile.lootToastFont = value
+					ns.RefreshLootToastSamples()
+				end,
+			}),
+			subToastFontSize = SubSelectRow(43, LootToastsOff, L["OPTIONS_LOOT_TOAST_FONT_SIZE"], {
+				type = "range",
+				min = ns.LOOT_TOAST_FONT_SIZE_MIN,
+				max = ns.LOOT_TOAST_FONT_SIZE_MAX,
+				step = 1,
+				get = function()
+					return ns.db.profile.lootToastFontSize
+				end,
+				set = function(_, value)
+					ns.db.profile.lootToastFontSize = value
+					ns.RefreshLootToastSamples()
+				end,
+			}),
+			subToastGrowth = SubSelectRow(38, LootToastsOff, L["OPTIONS_LOOT_TOAST_GROWTH"], {
+				type = "select",
+				values = {
+					UP = L["OPTIONS_GROW_UP"],
+					DOWN = L["OPTIONS_GROW_DOWN"],
+				},
+				sorting = { "UP", "DOWN" },
+				get = function()
+					return ns.db.profile.lootToastGrowth
+				end,
+				set = function(_, value)
+					ns.db.profile.lootToastGrowth = value
+					ns.RefreshLootToastSamples()
+				end,
+			}),
+			subToastAlign = SubSelectRow(39, LootToastsOff, L["OPTIONS_LOOT_TOAST_ALIGN"], {
+				type = "select",
+				values = {
+					LEFT = L["OPTIONS_ALIGN_LEFT"],
+					RIGHT = L["OPTIONS_ALIGN_RIGHT"],
+				},
+				sorting = { "LEFT", "RIGHT" },
+				get = function()
+					return ns.db.profile.lootToastAlign
+				end,
+				set = function(_, value)
+					ns.db.profile.lootToastAlign = value
+					ns.RefreshLootToastSamples()
+				end,
+			}),
+			subToastFontOutline = SubSelectRow(41, LootToastsOff, L["OPTIONS_LOOT_TOAST_OUTLINE"], {
+				type = "select",
+				values = FONT_FLAG_VALUES,
+				sorting = ns.LOOT_TOAST_FONT_FLAGS,
+				get = function()
+					return ns.db.profile.lootToastFontFlags
+				end,
+				set = function(_, value)
+					ns.db.profile.lootToastFontFlags = value
+					ns.RefreshLootToastSamples()
+				end,
+			}),
+			--[[
+                The position row hides with the sub-rows above rather than
+                greying out. Two dead buttons under a section whose other
+                controls have vanished reads as the whole feature being
+                unfinished, which is the opposite of what off should look like.
+            ]]
+			spaceToastPosition = {
+				type = "description",
+				name = " ",
+				order = 44,
+				hidden = LootToastsOff,
+			},
+			labelToastPosition = {
+				type = "description",
+				name = "",
+				fontSize = "medium",
+				width = TOAST_LABEL_WIDTH,
+				order = 45,
+				hidden = LootToastsOff,
+			},
+			toggleToastLock = {
+				type = "execute",
+				name = function()
+					return ns.AreLootToastsUnlocked() and L["OPTIONS_TOASTS_LOCK"] or L["OPTIONS_TOASTS_UNLOCK"]
+				end,
+				order = 46,
+				width = TOAST_BUTTON_WIDTH,
+				hidden = LootToastsOff,
+				func = function()
+					--[[
+                        Locking from here counts as having met the handle, the
+                        same as right-clicking it, so the introduction does not
+                        come back at the next login.
+                    ]]
+					if ns.AreLootToastsUnlocked() then
+						ns.DismissLootToastIntro()
+					end
+					ns.SetLootToastsUnlocked(not ns.AreLootToastsUnlocked())
+				end,
+			},
+			resetToastPosition = {
+				type = "execute",
+				name = L["OPTIONS_TOASTS_RESET"],
+				order = 47,
+				width = TOAST_BUTTON_WIDTH,
+				hidden = LootToastsOff,
+				func = function()
+					ns.ResetLootToastPosition()
+				end,
+			},
+		},
+	}
+end

--- a/Options/Options-Utilities.lua
+++ b/Options/Options-Utilities.lua
@@ -1,13 +1,14 @@
-local _, ns = ...
+local ADDON_NAME, ns = ...
 
 local GetColor = ns.GetColor
+local AceGUI = LibStub("AceGUI-3.0")
 
 --------------------------------------------------------------------------------
 -- Options Helpers
 --------------------------------------------------------------------------------
 
-function ns.OptionsHeader(text, order)
-	return { type = "header", name = GetColor("TITLE") .. text .. "|r", order = order }
+function ns.OptionsHeader(text, order, hidden)
+	return { type = "header", name = GetColor("TITLE") .. text .. "|r", order = order, hidden = hidden }
 end
 
 function ns.OptionsDesc(text, order)
@@ -18,6 +19,354 @@ function ns.OptionsSpacer(order)
 	return { type = "description", name = " ", order = order }
 end
 
-function ns.OptionsSubHeader(text, order)
-	return { type = "description", name = "\n" .. GetColor("TITLE") .. text .. "|r", fontSize = "medium", order = order }
+function ns.OptionsRowLabel(text, order, width)
+	return {
+		type = "description",
+		name = text,
+		fontSize = "medium",
+		width = width or ns.OPTIONS_LABEL_WIDTH,
+		order = order,
+	}
+end
+
+--------------------------------------------------------------------------------
+-- Sub-Option Rows
+--------------------------------------------------------------------------------
+
+--[[
+    A sub-option only means anything while the toggle above it is on, and is
+    marked two ways at once so the dependency reads whether the player is
+    scanning shape or colour: an indented checkbox and a silver caption.
+
+    The indent has to be a real widget - AceConfig pins a checkbox at the left
+    edge of its own widget, so padding the caption with spaces moves only the
+    text. One unnamed inline group per sub-option: a fill widget always takes a
+    line to itself, so the group pins exactly one row. `hidden` belongs on the
+    group, never on the members, or the indent is left behind on its own line
+    when the section collapses.
+
+    Three panels build sub-rows, so the shape lives here rather than being copied
+    into each of them, where the copies would drift apart.
+]]
+function ns.OptionsSubLabel(text)
+	return GetColor("HELP") .. text .. "|r"
+end
+
+function ns.OptionsSubRow(order, hidden, controls)
+	local args = {
+		subIndent = {
+			type = "description",
+			name = " ",
+			width = ns.OPTIONS_SUB_INDENT_WIDTH,
+			order = 1,
+		},
+	}
+	for index, control in ipairs(controls) do
+		control.order = index + 1
+		args["subControl" .. index] = control
+	end
+	return { type = "group", name = "", inline = true, order = order, hidden = hidden, args = args }
+end
+
+--[[
+    A caption beside a control, as one sub-row. The shape both quality dropdowns,
+    both lockbox scopes and the auto-open rules all use.
+]]
+--[[
+    labelWidth is for a panel whose captions are longer than the shared default
+    holds; it pairs with a narrower control so the row still totals the same.
+]]
+function ns.OptionsSubSelectRow(order, hidden, caption, control, labelWidth)
+	control.name = ""
+	control.width = control.width or ns.OPTIONS_SUB_CONTROL_WIDTH
+	return ns.OptionsSubRow(order, hidden, {
+		ns.OptionsRowLabel(ns.OptionsSubLabel(caption), nil, labelWidth or ns.OPTIONS_SUB_LABEL_WIDTH),
+		control,
+	})
+end
+
+--------------------------------------------------------------------------------
+-- Item Link Widget
+--------------------------------------------------------------------------------
+
+--[[
+    A read-only AceGUI widget drawing one item's icon and coloured link, with the
+    game's own tooltip on hover. AceConfig has no item-link control, so item-list
+    rows reach it through dialogControl = ns.ITEM_LINK_WIDGET_TYPE.
+
+    Registered under the add-on's own prefixed type name so it can never collide
+    with another add-on's widget of the same idea.
+]]
+ns.ITEM_LINK_WIDGET_TYPE = ADDON_NAME .. "_ItemLink"
+
+local ITEM_LINK_WIDGET_VERSION = 1
+local ITEM_LINK_ICON_SIZE = 16
+
+--[[
+    The row's own tooltip, plus the reason the row exists. AceConfigDialog's
+    InjectInfo hangs the whole option table off the widget's user data, so the
+    note travels as the option's `desc` with no extra plumbing — and because this
+    widget swallows AceConfigDialog's OnEnter, the note has to be drawn here or it
+    would never appear at all.
+]]
+local function ItemLinkOnEnter(frame)
+	local widget = frame.obj
+	if not widget.itemLink then
+		return
+	end
+	GameTooltip:SetOwner(frame, "ANCHOR_RIGHT")
+	GameTooltip:SetHyperlink(widget.itemLink)
+	local option = widget:GetUserDataTable().option
+	local note = option and option.desc
+	if note then
+		GameTooltip:AddLine(" ")
+		GameTooltip:AddLine(GetColor("TITLE") .. ns.L["ADDON_TITLE"] .. "|r")
+		GameTooltip:AddLine(GetColor("HELP") .. note .. "|r", nil, nil, nil, true)
+	end
+	GameTooltip:Show()
+end
+
+local function ItemLinkOnLeave()
+	GameTooltip:Hide()
+end
+
+local function CreateItemLinkWidget()
+	local frame = CreateFrame("Button", nil, UIParent)
+	frame:SetHeight(20)
+	frame:SetScript("OnEnter", ItemLinkOnEnter)
+	frame:SetScript("OnLeave", ItemLinkOnLeave)
+
+	local icon = frame:CreateTexture(nil, "ARTWORK")
+	icon:SetPoint("LEFT", frame, "LEFT", 0, 0)
+	icon:SetSize(ITEM_LINK_ICON_SIZE, ITEM_LINK_ICON_SIZE)
+
+	local label = frame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+	label:SetPoint("LEFT", icon, "RIGHT", 4, 0)
+	label:SetPoint("RIGHT", frame, "RIGHT", 0, 0)
+	label:SetJustifyH("LEFT")
+
+	local widget = {
+		type = ns.ITEM_LINK_WIDGET_TYPE,
+		frame = frame,
+		icon = icon,
+		label = label,
+		OnAcquire = function(self)
+			self:SetWidth(200)
+			self:SetText()
+		end,
+		OnRelease = function(self)
+			self.itemLink = nil
+		end,
+		--[[
+            AceConfig hands an input widget its value through SetText. The value
+            is the item link itself, so the widget parses the id back out of it
+            for the icon rather than being told twice.
+        ]]
+		SetText = function(self, text)
+			self.itemLink = text
+			if not text or text == "" then
+				self.icon:SetTexture(nil)
+				self.label:SetText("")
+				return
+			end
+			local itemId = tonumber(text:match("item:(%d+)"))
+			self.icon:SetTexture(itemId and GetItemIcon(itemId) or nil)
+			self.label:SetText(text)
+		end,
+		-- Read-only display: AceConfigDialog drives an input control through these.
+		SetLabel = function() end,
+		SetDisabled = function() end,
+		SetCallback = function() end,
+		DisableButton = function() end,
+		SetMaxLetters = function() end,
+	}
+	frame.obj = widget
+
+	return AceGUI:RegisterAsWidget(widget)
+end
+
+AceGUI:RegisterWidgetType(ns.ITEM_LINK_WIDGET_TYPE, CreateItemLinkWidget, ITEM_LINK_WIDGET_VERSION)
+
+--------------------------------------------------------------------------------
+-- Item Cache Warming
+--------------------------------------------------------------------------------
+
+--[[
+    GetItemInfo returns nil until the client has the item, so a freshly-logged-in
+    player would see bare ids where item links belong. Rows report outstanding ids
+    here; Core's GET_ITEM_INFO_RECEIVED handler calls back through
+    ns.OnItemInfoReceived, the list redraws as answers arrive, and the callback is
+    cleared once nothing is outstanding so the dispatcher stops doing work.
+]]
+local outstandingItems = {}
+local outstandingRegistry
+
+local function ClearItemInfoWatcher()
+	ns.OnItemInfoReceived = nil
+	outstandingRegistry = nil
+end
+
+local function OnItemInfoReceived(itemId)
+	if not outstandingItems[itemId] then
+		return
+	end
+	outstandingItems[itemId] = nil
+	local registryName = outstandingRegistry
+	if not next(outstandingItems) then
+		ClearItemInfoWatcher()
+	end
+	if registryName then
+		LibStub("AceConfigRegistry-3.0"):NotifyChange(registryName)
+	end
+end
+
+function ns.WatchUncachedItem(itemId, registryName)
+	outstandingItems[itemId] = true
+	outstandingRegistry = registryName
+	ns.OnItemInfoReceived = OnItemInfoReceived
+end
+
+--------------------------------------------------------------------------------
+-- Item Lists
+--------------------------------------------------------------------------------
+
+--[[
+    The shared player-managed item-list builder. A panel supplies its labels, the
+    source table, and the onAdd / onRemove / onRestore callbacks; the shape of the
+    list is owned here so every add-on's lists look and behave the same.
+
+    Rows are sorted by item NAME, not id — an id-ordered list reads as random.
+    Uncached rows sort under their raw id until the client answers, then the
+    refresh watcher above redraws them in place.
+
+    An optional config.noteFor(itemId) supplies a per-row explanation, carried as
+    the option's `desc` and drawn into the row's tooltip by the item-link widget.
+
+    Ids this client cannot resolve are dropped before a row is ever built. A saved
+    list can hold ids from a later expansion (the list is account-wide and the
+    defaults have since been expansion-filtered); GetItemInfoInstant answers
+    synchronously from the client's own database, so it separates "not cached yet"
+    from "does not exist here" without waiting on an event that will never fire.
+]]
+local REMOVE_ICON = "Interface/Buttons/UI-GroupLoot-Pass-Up"
+local REMOVE_ICON_SIZE = 16
+
+local function ParseItemId(input)
+	if not input then
+		return nil
+	end
+	local fromLink = input:match("item:(%d+)")
+	if fromLink then
+		return tonumber(fromLink)
+	end
+	return tonumber(input:match("^%s*(%d+)%s*$"))
+end
+
+function ns:BuildItemListOptions(config)
+	local args = {}
+	-- The panel owns everything below config.startOrder, so it can put its own
+	-- copy and controls above the list without renumbering the shared shape.
+	local order = (config.startOrder or 1) - 1
+	local function nextOrder()
+		order = order + 1
+		return order
+	end
+
+	if config.onRestore then
+		args.restore = {
+			type = "execute",
+			name = config.restoreLabel,
+			desc = config.restoreLabel,
+			order = nextOrder(),
+			width = "double",
+			confirm = true,
+			confirmText = config.restoreConfirm,
+			func = config.onRestore,
+		}
+		args.restoreSpacer = ns.OptionsSpacer(nextOrder())
+	end
+
+	args.addLabel = ns.OptionsRowLabel(config.addLabel, nextOrder())
+	args.addInput = {
+		type = "input",
+		name = "",
+		desc = config.addHint,
+		order = nextOrder(),
+		width = ns.OPTIONS_CONTROL_WIDTH,
+		get = function()
+			return ""
+		end,
+		set = function(_, value)
+			local itemId = ParseItemId(value)
+			if itemId then
+				config.onAdd(itemId)
+			end
+		end,
+	}
+	args.addSpacer = ns.OptionsSpacer(nextOrder())
+
+	local rows = {}
+	for itemId in pairs(config.source) do
+		if GetItemInfoInstant(itemId) then
+			local name, link = GetItemInfo(itemId)
+			if not name then
+				ns.WatchUncachedItem(itemId, config.registryName)
+			end
+			rows[#rows + 1] = { itemId = itemId, name = name, link = link }
+		end
+	end
+	table.sort(rows, function(a, b)
+		if (a.name ~= nil) ~= (b.name ~= nil) then
+			return a.name ~= nil
+		end
+		if a.name and b.name and a.name ~= b.name then
+			return a.name < b.name
+		end
+		return a.itemId < b.itemId
+	end)
+
+	for _, row in ipairs(rows) do
+		local itemId = row.itemId
+		args["item" .. itemId] = {
+			type = "group",
+			name = "",
+			inline = true,
+			order = nextOrder(),
+			args = {
+				link = {
+					type = "input",
+					name = "",
+					desc = config.noteFor and config.noteFor(itemId) or nil,
+					dialogControl = ns.ITEM_LINK_WIDGET_TYPE,
+					order = 1,
+					width = ns.OPTIONS_ROW_WIDTH - ns.OPTIONS_REMOVE_ICON_WIDTH,
+					get = function()
+						return row.link or tostring(itemId)
+					end,
+					set = function() end,
+				},
+				--[[
+                    Remove is an icon, not a labelled button: the stock Button
+                    insets its font string 15px per edge, which clips a caption to
+                    a sliver in a column this narrow. One click, no confirm —
+                    Restore Defaults is the destructive action that confirms.
+                ]]
+				remove = {
+					type = "execute",
+					name = "",
+					desc = config.removeLabel,
+					order = 2,
+					width = ns.OPTIONS_REMOVE_ICON_WIDTH,
+					image = REMOVE_ICON,
+					imageWidth = REMOVE_ICON_SIZE,
+					imageHeight = REMOVE_ICON_SIZE,
+					func = function()
+						config.onRemove(itemId)
+					end,
+				},
+			},
+		}
+	end
+
+	return args
 end

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -15,18 +15,38 @@ local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 --[[
     Registration only. Called from EventHandlers:PLAYER_LOGIN once ns.db exists,
     because the Profiles builder needs the AceDB database — calling it at file
-    load would hit a nil ns.db. Child order is General (root) -> Profiles
-    second-to-last -> Diagnostic Tools last; each panel's parent argument
+    load would hit a nil ns.db. Child order is General (root) -> Notifications ->
+    Lockboxes -> Ignore List -> Profiles second-to-last -> Diagnostic Tools last;
+    each panel's parent argument
     (L["ADDON_TITLE"]) nests it under Open Sesame. The Profiles display name comes
     already localized from AceDBOptions-3.0.
 ]]
 function ns:RegisterOptionsPanels()
 	AceConfigRegistry:RegisterOptionsTable(ns.OPTIONS_REGISTRY.General, ns.BuildGeneralOptions())
-	-- AddToBlizOptions returns (frame, categoryID). The ID is what Settings.OpenToCategory
-	-- expects; relying on the localized name matching the ID is fragile (the library only
-	-- aliases ID to name on older clients), so capture the real reference here.
+	--[[
+        AddToBlizOptions returns (frame, categoryID). The ID is what
+        Settings.OpenToCategory expects; relying on the localized name matching
+        the ID is fragile (the library only aliases ID to name on older
+        clients), so capture the real reference here.
+    ]]
 	ns.GeneralPanel, ns.GeneralCategoryID =
 		AceConfigDialog:AddToBlizOptions(ns.OPTIONS_REGISTRY.General, L["ADDON_TITLE"])
+
+	AceConfigRegistry:RegisterOptionsTable(ns.OPTIONS_REGISTRY.Notifications, ns.BuildNotificationsOptions())
+	AceConfigDialog:AddToBlizOptions(ns.OPTIONS_REGISTRY.Notifications, L["TAB_NOTIFICATIONS"], L["ADDON_TITLE"])
+
+	AceConfigRegistry:RegisterOptionsTable(ns.OPTIONS_REGISTRY.Lockboxes, ns.BuildLockboxesOptions())
+	AceConfigDialog:AddToBlizOptions(ns.OPTIONS_REGISTRY.Lockboxes, L["TAB_LOCKBOXES"], L["ADDON_TITLE"])
+
+	--[[
+        The Ignore List's rows change as the player edits them, so it registers
+        the BUILDER rather than a built table: AceConfigRegistry calls a function
+        table afresh on every fetch, which is what makes NotifyChange redraw new
+        and removed rows. A static table would only ever redraw the rows that
+        existed at login.
+    ]]
+	AceConfigRegistry:RegisterOptionsTable(ns.OPTIONS_REGISTRY.IgnoreList, ns.BuildIgnoreListOptions)
+	AceConfigDialog:AddToBlizOptions(ns.OPTIONS_REGISTRY.IgnoreList, L["TAB_IGNORE_LIST"], L["ADDON_TITLE"])
 
 	-- Profiles registered second-to-last, directly above Diagnostic Tools.
 	local profilesOptions = ns.BuildProfilesOptions()
@@ -42,23 +62,27 @@ end
 -- Slash Commands
 --------------------------------------------------------------------------------
 
-local function OpenOptions()
-	if Settings and Settings.OpenToCategory and ns.GeneralCategoryID then
-		Settings.OpenToCategory(ns.GeneralCategoryID)
+--[[
+    Shared entry point: the slash command and the minimap button's Shift +
+    Middle-Click both open here. The combat gate lives only here — Blizzard's
+    Settings panel is protected in combat, and without it the player gets an
+    ADDON_ACTION_BLOCKED error naming the add-on. Routing uses the category ID
+    captured at registration; passing the title instead returns nil on any client
+    with the Settings API and drops the panel into a floating window.
+]]
+function ns:OpenOptionsPanel()
+	if InCombatLockdown() then
+		ns:PrintMessage(L["CHAT_OPTIONS_IN_COMBAT"])
 		return
 	end
-	if InterfaceOptionsFrame_OpenToCategory then
-		InterfaceOptionsFrame_OpenToCategory(L["ADDON_TITLE"])
-		InterfaceOptionsFrame_OpenToCategory(L["ADDON_TITLE"])
+	if Settings and Settings.OpenToCategory and ns.GeneralCategoryID then
+		Settings.OpenToCategory(ns.GeneralCategoryID)
 		return
 	end
 	AceConfigDialog:Open(ns.OPTIONS_REGISTRY.General)
 end
 
--- Shared entry point: the slash command and the minimap button's Shift+Middle-Click both open here.
-function ns:OpenOptionsPanel()
-	OpenOptions()
-end
-
 SLASH_OPENSESAME1 = "/os"
-SlashCmdList.OPENSESAME = OpenOptions
+SlashCmdList.OPENSESAME = function()
+	ns:OpenOptionsPanel()
+end

--- a/README-Technical.md
+++ b/README-Technical.md
@@ -1,4 +1,4 @@
-# Open Sesame — Technical Reference
+# Open Sesame // Technical Reference
 
 This document combines architecture notes and contribution guidance for developers working on Open Sesame. For end-user documentation, see [README.md](https://github.com/Gogo1951/Open-Sesame/blob/main/README.md).
 
@@ -6,213 +6,486 @@ This document combines architecture notes and contribution guidance for develope
 
 ```text
 Open-Sesame/
-├── Open-Sesame.toc              Load order, metadata, SavedVariables declaration
-├── README.md                    Player-facing documentation
-├── README-Technical.md          This file
-│
+├── .github/
+│   └── workflows/
+│       └── package.yml            CurseForge release and library vendoring
+├── .gitattributes                 Line-ending normalization
+├── .gitignore                     Dev-clutter ignore list
+├── .luacheckrc                    Lint config
+├── .pkgmeta                       Externals and packager ignore list
+├── Open-Sesame.toc                Load order, metadata, SavedVariables declaration
 ├── Data/
-│   ├── Data.lua                 Constants, spell/sound IDs, color palette, and the
-│   │                            hand-curated AllowedItems / IgnoreItems tables
-│   └── Default-Settings.lua     ns.DATABASE_DEFAULTS (AceDB profile + global defaults)
-│
+│   ├── Data.lua                   Constants, palette, spell and sound ids, options grid, registry names
+│   ├── Default-Settings.lua       ns.DATABASE_DEFAULTS plus ns.DEFAULT_IGNORE_ITEMS
+│   └── Openable-Items.lua         ns.AllowedItems, the generated openable-container table
 ├── Features/
-│   ├── Core.lua                 Event dispatcher, scan/queue/open pipeline, pause logic,
-│   │                            profile application, SavedVariables migration
-│   ├── Utilities.lua            C_Container API selection, color derivation, GetFreeSlots
-│   ├── Announcements.lua        PrintMessage, the deduped StatusPrint channel, quiet window
-│   ├── Speedy-Loot.lua          LOOT_READY handler, loot-window suppression, master-looter guard
-│   ├── Diagnostics.lua          Read-only bug-report probes (events, API, loot method, dumps)
-│   └── Minimap-Button.lua       LibDataBroker launcher, tooltip, click handlers
-│
-├── Options/
-│   ├── Options.lua              Registers the three AceConfig panels; /os slash command
-│   ├── Options-General.lua      Main settings panel (toggles, links, version)
-│   ├── Options-Utilities.lua    Shared header/description/spacer widget builders
-│   ├── Options-Profiles.lua     Stock AceDBOptions-3.0 profiles table, returned as-is
-│   └── Options-Diagnostics.lua  Gated diagnostics panel wiring the Diagnostics.lua probes
-│
+│   ├── Core.lua                   Event dispatcher, scan/queue/open pipeline, pause state, profile apply
+│   ├── Utilities.lua              C_Container references, color and money helpers, lockbox scope predicates
+│   ├── Announcements.lua          PrintMessage, the deduped status channel, the quiet window
+│   ├── Ignore-List.lua            Account-wide Ignore List: seed, query, mutate
+│   ├── Speedy-Loot.lua            Loot-window suppression and the master-looter stand-down
+│   ├── Lockbox-Tooltips.lua       Lockpicking requirement line on locked containers
+│   ├── Loot-Toasts.lua            On-screen readout of what was just looted
+│   ├── Diagnostics.lua            Read-only bug-report probes and the event log
+│   └── Minimap-Button.lua         LibDataBroker launcher, tooltip, click handlers
+├── Includes/
+│   ├── Images/
+│   │   └── Open-Sesame.tga        Add-on icon
+│   ├── Libraries/                 Vendored third-party code, never hand-edited
+│   └── Sounds/
+│       └── item-pick-up.ogg       The rare-loot chime
 ├── Locales/
-│   ├── enUS.lua                 Source of truth (NewLocale ..., true)
-│   └── deDE/esES/esMX/frFR/     Translations; fall back to enUS via AceLocale __index
-│       itIT/koKR/ptBR/ruRU/
-│       zhCN/zhTW.lua
-│
-└── Includes/
-    ├── Images/Open-Sesame.tga   Add-on icon
-    └── Libraries/               Embedded Ace3 stack, LibStub, CallbackHandler,
-                                 LibDataBroker-1.1, LibDBIcon-1.0
+│   ├── enUS.lua                   Source of truth, the only file passing the true fallback flag
+│   └── (ten more locale files)    deDE, esES, esMX, frFR, itIT, koKR, ptBR, ruRU, zhCN, zhTW
+├── Options/
+│   ├── Options-Utilities.lua      Shared widget helpers, sub-rows, item-link widget, item-list builder
+│   ├── Options-General.lua        Root panel
+│   ├── Options-Notifications.lua  Loot Sound, Pick Pocket sound, Loot Toasts
+│   ├── Options-Lockboxes.lua      Lockbox tooltips and lockbox notifications
+│   ├── Options-Ignore-List.lua    Ignore List panel: copy and callbacks only
+│   ├── Options-Profiles.lua       Stock AceDBOptions-3.0 table, returned unmodified
+│   ├── Options-Diagnostics.lua    The gated Diagnostic Tools panel
+│   └── Options.lua                Panel registration, the options opener, /os
+├── LICENSE                        MIT
+├── README.md                      Player-facing documentation
+└── README-Technical.md            This file
 ```
 
-No deprecated or dead files are present. Every `Features/`, `Options/`, and `Data/` file is listed in the TOC load order.
+No deprecated or dead files are present, and every `Data/`, `Features/`, `Options/`, and `Locales/` file is listed in the TOC load order. `Includes/Libraries/` vendors LibStub, CallbackHandler-1.0, the Ace3 stack (AceLocale, AceDB, AceGUI, AceConfig, AceDBOptions), LibDataBroker-1.1 and LibDBIcon-1.0 for the mini-map button, and LibSharedMedia-3.0 for the Loot Toasts font picker.
 
 ## Architecture
 
 ### Event Loop
 
-A single hidden frame in [Core.lua](Features/Core.lua) owns every event. Its `OnEvent` script logs the event when diagnostics logging is active, then dispatches to a handler keyed by event name in the `EventHandlers` table. Handlers are plain functions (or shared aliases such as `EventHandlers.BAG_UPDATE_DELAYED = OnScanRequest`); nothing else registers events directly.
+A single hidden frame in [Core.lua](Features/Core.lua) owns every event. Its `OnEvent` script logs the firing when diagnostics logging is active, then dispatches to a handler keyed by event name in the `EventHandlers` table. Handlers are plain functions, or aliases onto a shared helper (`EventHandlers.BAG_UPDATE_DELAYED = OnScanRequest`). Nothing else in the add-on registers an event.
 
-Registration is driven from the `EventHandlers` table itself, so the frame can never listen for an event that has no handler and vice versa:
+Registration is driven from the `EventHandlers` table itself, so the frame can never listen for an event that has no handler, or hold a handler nothing routes to:
 
 - `ns.EVENT_NAMES` is built by iterating `EventHandlers`, sorted, and exported so [Diagnostics.lua](Features/Diagnostics.lua) probes the exact set the add-on uses.
-- Registration walks the same keys and calls `C_EventUtils.IsEventValid` first (falling back to a `pcall`-guarded `RegisterEvent`), so an event name absent on a future client build is skipped instead of aborting the loop.
+- Registration walks the same keys and skips any name `C_EventUtils.IsEventValid` rejects, so an event absent on a future client build is skipped rather than aborting the loop. Every name in the table is valid on both target clients today.
+- `UNIT_SPELLCAST_SUCCEEDED` is the one special case: it registers through `RegisterUnitEvent(event, "player")` so the frame does not wake on every group member's cast. The handler keeps its own `unit == "player"` guard as well.
 
-Most bag/loot events funnel into `OnScanRequest → ScheduleScan()`, which debounces (see below). Interaction-close events (`MERCHANT_CLOSED`, `MAIL_CLOSED`, `BANKFRAME_CLOSED`, `GOSSIP_CLOSED`, `QUEST_FINISHED`, `PLAYER_INTERACTION_MANAGER_FRAME_HIDE`) share `OnInteractionClosed`, which forces an immediate rescan and flushes any held status message.
+Most bag and loot events funnel into `OnScanRequest`, which calls the debounced `ScheduleScan()`. The interaction-close events (`MERCHANT_CLOSED`, `MAIL_CLOSED`, `BANKFRAME_CLOSED`, `GOSSIP_CLOSED`, `QUEST_FINISHED`, `PLAYER_INTERACTION_MANAGER_FRAME_HIDE`) share `OnInteractionClosed`, which forces an immediate rescan and flushes any held status message. `TRADE_CLOSED` runs that same helper plus a second delayed scan, for the reason given under [Auto-Opening Queue](#auto-opening-queue).
 
-### Combat & Safety Gating
+### Combat and Safety Gating
 
-Open Sesame never uses protected macros, so there is no dirty-flag/replay pattern. Instead, all opening funnels through `IsSafeToOpen()`, which refuses to act while any of these hold: the add-on is disabled or paused, the player is in combat (`UnitAffectingCombat`), a merchant/mail/trade/bank/guild-bank/auction/gossip/quest/static-popup frame is open (`IsInteractionActive`), the player is stealthed (`IsStealthed` **or** carrying the Shadowmeld aura — see [Common Pitfalls](#common-pitfalls)), a cast or channel is in progress, or a genuine item tooltip is showing.
+**Open Sesame never casts anything and owns no secure frames.** It writes no macros and creates no protected buttons, so there is no dirty-flag replay pattern and no taint surface to reason about: the add-on opens containers and reports what it finds.
 
-Combat itself is handled by deferral rather than a queue replay: the open tick simply stops firing while `IsSafeToOpen` is false, and `PLAYER_REGEN_ENABLED` forces a fresh scan the moment combat ends. `UPDATE_STEALTH` does the same when the player leaves stealth. This keeps the design free of any combat-lockdown taint surface.
+Two things behave differently in combat.
+
+**The options opener refuses outright.** `ns:OpenOptionsPanel` in [Options.lua](Options/Options.lua) checks `InCombatLockdown()` first, prints `CHAT_OPTIONS_IN_COMBAT`, and returns. It never queues, retries, or waits for `PLAYER_REGEN_ENABLED`. The gate sits in the opener and nowhere else, so the `/os` handler and the mini-map button's Shift + Middle-Click share one copy of it. Blizzard's Settings panel is protected in combat, and without the gate the player gets an `ADDON_ACTION_BLOCKED` error naming the add-on.
+
+**Opening defers instead.** Everything that opens a container funnels through `IsSafeToOpen()`, which refuses while any of these hold: the add-on is disabled or paused, the player is in combat (`UnitAffectingCombat`), a merchant, mail, trade, bank, guild bank, auction, gossip, quest, or static-popup frame is open (`IsInteractionActive`), the player is stealthed (`IsStealthed` or carrying the Shadowmeld aura, see [Common Pitfalls](#common-pitfalls)), a cast or channel is in progress, a genuine item tooltip is showing, or free bag slots are below `ns.MIN_FREE_SLOTS`. There is no queue replay: the open tick simply stops firing, and `PLAYER_REGEN_ENABLED` forces a fresh scan the moment combat ends. `UPDATE_STEALTH` does the same when the player leaves stealth.
+
+### Where and Group Hold-Offs
+
+`IsSafeToOpen` also honours two player-set hold-offs, both defaulting to the original always-open behaviour:
+
+- **`autoOpenWhere`**, `"ALWAYS"` (shown as *Anywhere*) or `"OUTSIDE_INSTANCES"`; the latter refuses while `IsInInstance()` is true.
+- **`autoOpenGroup`**, `"ALWAYS"` (shown as *Solo or Grouped*) or `"SOLO_ONLY"`; the latter refuses while `IsInGroup()` is true, party or raid.
+
+Both stored values are `ALWAYS` while the visible copy differs, on purpose: each dropdown's options have to answer its own label, so *Where* offers places and *Group* offers group states. One shared "Always" string read as though the two rows were duplicates of each other, and neither value answered the question its label asked.
+
+The point is bag space: a player running dungeons wants slots free for drops, with the boxes opened later on their own time. Because both are read inside `IsSafeToOpen` rather than applied imperatively, nothing has to be re-applied on a profile switch. Two rescan paths cover leaving either state: `GROUP_ROSTER_UPDATE` (aliased to `OnScanRequest`) covers joining and leaving a group, and the non-initial branch of `PLAYER_ENTERING_WORLD` fires a debounced `ScheduleScan()` so zoning out of an instance resumes opening without waiting on a bag event.
 
 ### Scan → Queue → Open
 
 The pipeline lives entirely in [Core.lua](Features/Core.lua) and runs in three phases:
 
-1. **Scan** — `ScheduleScan(force)` debounces bag churn. Unforced calls coalesce inside `ns.SCAN_DEBOUNCE` (0.5s) using a pending flag and a timestamp; only the newest request survives. Forced calls (profile apply, combat end, pick-lock settle, interaction close) run immediately. Each run recomputes free slots, updates the pause state with hysteresis, and — if enabled — rebuilds the queue.
-2. **Queue** — `BuildQueue()` walks bags 0–4, resolves each slot's item ID via `SafeFastItemID`, and pushes it when `ns.AllowedItems[id]` is `true` (open now) or `false` **and** the tooltip does not report the item as `LOCKED`. The queue is a flat array of `(bag, slot, itemId)` triples with head/tail cursors, wiped and reset when drained.
-3. **Open** — `OpenTick()` fires every `ns.OPEN_TICK_INTERVAL` (0.25s). It re-verifies safety, pops one triple, confirms the slot still holds the cached item ID, calls `UseContainerItem`, then schedules a recheck after `ns.OPEN_RECHECK_DELAY` to requeue the slot if the item survived (a locked box that produced another openable, etc.). A single `openTimerLive` flag prevents overlapping tick chains.
+1. **Scan.** `ScheduleScan(force)` absorbs bag churn. Unforced calls coalesce inside `ns.SCAN_DEBOUNCE` (0.5s) behind a pending flag and a timestamp, so only the newest request survives. Forced calls (profile apply, combat end, pick-lock settle, interaction close, ignore-list edit) run immediately. Each run recomputes free slots, updates the pause state, announces a change of state, and, when enabled, rebuilds the queue. `RunScan` and its debounce callback are file-locals rather than closures built inside `ScheduleScan`, because every bag or loot event would otherwise allocate two throwaway functions before deciding whether a scan is needed at all.
+2. **Queue.** `BuildQueue()` walks bags 0 to 4, resolves each slot's item id through `SafeFastItemID`, and pushes it when `ns.AllowedItems[id]` is `true` (open now) or `false` and the tooltip does not report the item as `LOCKED`. Ignored ids never enter the queue. The queue is a flat array of `(bag, slot, itemId)` triples with head and tail cursors, wiped and reset when drained.
+3. **Open.** `OpenTick()` fires every `ns.OPEN_TICK_INTERVAL` (0.25s). It re-verifies safety, pops one triple, confirms the slot still holds the cached id, calls `UseContainerItem`, then schedules a recheck after `ns.OPEN_RECHECK_DELAY` that requeues the slot if the same item is still sitting there. A single `openTimerLive` flag prevents overlapping tick chains. A cast or channel in progress reschedules the tick rather than dropping it, so the chain survives a mid-queue cast.
 
 ### Item Identity Caching
 
-Open Sesame keys everything off numeric item IDs, not `GetItemInfo`. `SafeFastItemID(bag, slot)` first tries `ns.GetContainerItemID` (synchronous, never a cold-cache nil), and only if that returns nil falls back to parsing the item ID out of `ns.GetContainerItemLink`. Because the ID comes straight from the container API, there is no asynchronous `GetItemInfo` cold-call to guard and no per-item cache to invalidate. The eligibility data — `ns.AllowedItems` and `ns.IgnoreItems` in [Data.lua](Data/Data.lua) — is a compile-time constant, not a runtime cache.
+Open Sesame keys everything off numeric item ids, never off `GetItemInfo`. `SafeFastItemID(bag, slot)` tries `ns.GetContainerItemID` first, which answers synchronously from the client's own database with no cold-cache nil, and only falls back to parsing the id out of `ns.GetContainerItemLink`. Because the id comes straight from the container API, the opening pipeline has no asynchronous cold call to guard and no per-item cache to invalidate.
 
-The container API references themselves are resolved once in [Utilities.lua](Features/Utilities.lua): each `ns.GetContainer*` upvalue picks `C_Container.X` on modern builds or the legacy global `X` where the namespace is absent. The selection stores a function *reference* (never a call result), so it sidesteps the truthy-fallthrough trap that bans `or` between call results.
+`GetItemInfo` cold-call nils do appear in two places, and both are handled where they arise rather than through a shared cache:
+
+- **The Ignore List panel** draws item links, so a row whose item the client has not cached yet registers through `ns.WatchUncachedItem`. See [Panel and the Shared Item-List Builder](#panel-and-the-shared-item-list-builder).
+- **Loot Toasts' Bind on Pickup bypass** reads `bindType` from the full `GetItemInfo`. A nil reads as "not Bind on Pickup" and leaves the quality threshold to decide, which is acceptable because the item was just looted, the one moment the client is certain to have it cached.
+
+`ns.AllowedItems` in [Openable-Items.lua](Data/Openable-Items.lua) is a compile-time constant, not a runtime cache. The container API references themselves are cached once in [Utilities.lua](Features/Utilities.lua) as plain unguarded upvalues.
+
+### Client Targets and API Surface
+
+Open Sesame targets **Classic Era (1.15.x)** and **TBC Anniversary (2.5.x)**. On the API surface this add-on touches, the two flavors are in sync: both ship the namespaced APIs and both have already removed the identically-named legacy globals. The Diagnostics panel's **API Endpoints** report is what proves that on a given client.
+
+**There are no compatibility shims.** Every API below is called directly, unguarded, with one exception noted in the last row:
+
+| Used | Removed from both clients, do not call |
+| --- | --- |
+| `C_AddOns.GetAddOnMetadata` / `.GetAddOnInfo` / `.GetNumAddOns` | `GetAddOnMetadata`, `GetAddOnInfo`, `GetNumAddOns` |
+| `C_Container.GetContainerNumSlots` / `.GetContainerNumFreeSlots` / `.GetContainerItemID` / `.GetContainerItemLink` / `.UseContainerItem` | `GetContainerNumSlots`, `GetContainerNumFreeSlots`, `GetContainerItemID`, `GetContainerItemLink`, `UseContainerItem` |
+| `C_PartyInfo.GetLootMethod`, which returns an enum **number** | `GetLootMethod`, which returned a string |
+| `C_UnitAuras.GetBuffDataByIndex` | `UnitBuff`, still present, but its `spellId` return position differs between Era and TBC |
+| `C_CVar.GetCVar` / `.GetCVarBool` / `.SetCVar` | `GetCVar` / `SetCVar`, still present but unused, so CVar access has one shape |
+| `C_EventUtils.IsEventValid`, `C_Timer.After` | |
+| `LE_GAME_ERR_INV_FULL` | `Enum.UIERRORS.ERR_INV_FULL`, absent on both clients |
+| `Settings.OpenToCategory`, the one availability guard the add-on keeps | |
+
+Two values are written out as literals rather than read from an `Enum` table, because `Enum.LootMethod` is not guaranteed on these builds: `LOOT_METHOD_MASTER = 2` in [Speedy-Loot.lua](Features/Speedy-Loot.lua) and its twin in [Diagnostics.lua](Features/Diagnostics.lua), where the Loot Method report prints the live returns that verify the mapping.
+
+Every API in the left column has a row in `ns.DIAGNOSTIC_API_CHECKS`. Because nothing is guarded, a `[FAIL]` row is a real break on that client rather than a note that a fallback took over. **Before adding a flavor guard or a legacy fallback, run the API Endpoints report on both clients and let it prove the difference.**
 
 ## Auto-Opening Queue
 
-The queue deliberately handles two kinds of items differently, encoded by the value in `ns.AllowedItems`:
+The queue handles two kinds of item differently, encoded by the value in `ns.AllowedItems`:
 
-- `true` — safe to open on sight (clams, coin pouches, gift boxes). Queued whenever present.
-- `false` — a lockbox or locked chest. Queued **only once the client reports it unlocked**, detected by scanning the item's tooltip lines for the global `LOCKED` string (`IsItemLocked`). Until then it sits in the bag.
+- `true`, safe to open on sight (clams, coin pouches, gift boxes). Queued whenever present.
+- `false`, a lockbox or locked chest. Queued **only once the client reports it unlocked**, detected by scanning the item's tooltip lines for the global `LOCKED` string (`ns.IsItemLocked`). Until then it sits in the bag.
+
+`LOCKED` is matched against the whole tooltip line, never as a substring: it is a short word, and other add-ons write lines that contain it without meaning it.
 
 When Auto Loot delivers a still-locked box, the `false` entry is skipped, so it waits. Two events re-trigger a scan so a freshly unlocked box opens without waiting for the next bag update:
 
-- `UNIT_SPELLCAST_SUCCEEDED` for the player's own **Pick Lock** (spell 1804) → rescan after `ns.PICK_LOCK_RESCAN_DELAY` (0.5s settle).
-- `TRADE_CLOSED` → immediate rescan **plus** a second forced scan after the same settle delay, because another rogue picking locks on boxes in the trade window fires no event on our side and the unlocked state often has not settled client-side when `TRADE_CLOSED` arrives.
+- `UNIT_SPELLCAST_SUCCEEDED` for the player's own **Pick Lock** (spell 1804), which rescans after `ns.PICK_LOCK_RESCAN_DELAY` (0.5s of settle).
+- `TRADE_CLOSED`, which runs the shared immediate rescan **and** a second forced scan after that same settle delay. Another rogue picking locks on boxes in the trade window fires no event on our side, and the unlocked state often has not settled client-side by the time `TRADE_CLOSED` arrives, so an immediate scan alone still reads the boxes as locked.
 
-`ITEM_WILL_AUTO_OPEN` is printed (when lockbox notifications are on) the first time a `false` item is looted, so the player knows it is queued rather than ignored.
+`ITEM_WILL_AUTO_OPEN` prints when a `false` item is looted, so the player knows it is queued rather than ignored. It is gated by `ns.LockboxNotificationsEnabled()` **and** by `autoOpen`, since the message promises automatic opening: with Auto-Opening off there is nothing to promise, so the notice stays quiet even though its own toggle lives under **Lockboxes**. The sibling `ITEM_OPEN_MANUALLY` notice in Speedy Loot carries the same pairing.
+
+## Ignore List
+
+[Ignore-List.lua](Features/Ignore-List.lua) owns the player's list of containers Open Sesame leaves alone entirely: Speedy Loot leaves them in the loot window with an `ITEM_OPEN_MANUALLY` notice, and Auto-Opening never queues them even when `ns.AllowedItems` allows the item. Every consumer asks the same question, `ns:IsIgnored(itemId)`: `BuildQueue`, the `OpenTick` recheck, `ns.GetLockedBoxes`, the `ITEM_WILL_AUTO_OPEN` notice in `CHAT_MSG_LOOT`, and Speedy Loot's per-slot skip.
+
+**The list is account-wide**, in `ns.db.global.ignoreList`. Which containers a player hoards is a decision about the items, not about the character, so it must not move or reset with a profile.
+
+**Two tables, two shapes, and they are not interchangeable.** `ns.DEFAULT_IGNORE_ITEMS` in [Default-Settings.lua](Data/Default-Settings.lua) is the shipped seed and stores `{ expansionThatAddedIt, reasonKey }` per id. The saved list stores `true` per id and nothing else. `SeedFrom` writes `true`, never the entry.
+
+That split is deliberate. The reason is looked up from `ns.DEFAULT_IGNORE_ITEMS` at read time rather than copied in at seed time, so a list saved before the notes existed still shows them and better copy reaches every player without a migration. The reason itself resolves to one of six locale keys (`RAID`, `QUEST`, `RECIPE`, `GEAR`, `HOLIDAY`, `ITEM`) rather than carrying its own sentence, because free text per row would be one string per row for every locale to translate, sitting outside `Locales/` entirely. Item names stay out of those strings: the client already draws its own localized tooltip directly above the line, so naming the loot again would ship English item names into every locale. `ns:GetIgnoreNote` prefixes the reason with `ns.ICON_IGNORED`, the client's own red pass icon, so the row reads as refused at a glance, and returns nil for anything the player added.
+
+**Seeding follows the house default-list rule.** `ns:SeedIgnoreList` runs from `PLAYER_LOGIN` right after `AceDB:New` and rebuilds only when the saved list is missing or empty. Note what that means at the edge: an empty list is indistinguishable from a fresh install, so a player who removes *every* row keeps it empty for the rest of the session and finds it reseeded at their next login. Removing rows individually is what sticks, which is the case the rule exists for.
+
+**Seeding and Restore Defaults both filter by expansion.** Only rows whose tag is at or below `ns.currentExpansion` are written. An id from a later expansion never answers `GetItemInfo` on this client, so it would sit in the panel as a bare number forever and keep the refresh watcher armed waiting for news that never comes.
+
+Every mutation (`ns:AddIgnoredItem`, `ns:RemoveIgnoredItem`, `ns:RestoreDefaultIgnoreList`) forces a rescan and ends in `AceConfigRegistry:NotifyChange` on the Ignore List registry so the panel redraws.
+
+### Panel and the Shared Item-List Builder
+
+The panel itself ([Options-Ignore-List.lua](Options/Options-Ignore-List.lua)) supplies only copy, the source table, and callbacks. The shape comes from `ns:BuildItemListOptions` in [Options-Utilities.lua](Options/Options-Utilities.lua): Restore Defaults (confirmed), an add box that parses a dragged item, a pasted link, or a bare id and clears itself, then one inline group per item sorted **by item name**, each row an item-link cell plus an icon-only remove button whose widths total `ns.OPTIONS_ROW_WIDTH`. The panel starts its list at `startOrder = 10`, leaving orders 1 to 9 for its own description and the Ignore List notifications toggle.
+
+Four mechanics are worth knowing before editing it:
+
+- **It registers the builder, not a built table.** `AceConfigRegistry:RegisterOptionsTable` accepts a function and calls it afresh on every fetch, which is what lets `NotifyChange` draw rows that did not exist at login. Registering `ns.BuildIgnoreListOptions()` instead of `ns.BuildIgnoreListOptions` would freeze the list at its login contents.
+- **Uncached items resolve through Core's dispatcher.** `GetItemInfo` returns nil until the client has the item, so a row with no answer yet registers through `ns.WatchUncachedItem`, which sets `ns.OnItemInfoReceived`. Core's `GET_ITEM_INFO_RECEIVED` handler calls it, the list redraws as answers arrive, and the callback clears once nothing is outstanding so the dispatcher stops doing work. Uncached rows sort under their raw id until then, and no bare id is left standing.
+- **Unresolvable ids are dropped before a row is built.** A saved list can hold ids from a later expansion, so each row is tested with `GetItemInfoInstant` first. That answers synchronously from the client's own database, which is what separates "not cached yet" from "does not exist here" without waiting on an event that will never fire.
+- **The row's note is drawn by the widget, not by AceConfig.** `noteFor(itemId)` is carried as the option's `desc`; AceConfigDialog's `InjectInfo` hangs the option table off the widget's user data, and the item-link widget reads `option.desc` in its own `OnEnter` and appends it under the item tooltip. That last step is required rather than incidental: the widget replaces AceConfigDialog's `OnEnter` so it can show the game's item tooltip, which means a `desc` would otherwise never be drawn at all.
 
 ## Speedy Loot
 
-[Speedy-Loot.lua](Features/Speedy-Loot.lua) loots corpses instantly and hides the loot window. The non-obvious parts:
+[Speedy-Loot.lua](Features/Speedy-Loot.lua) loots corpses instantly and hides the loot window. `ns.HandleSpeedyLoot` is invoked from Core's `LOOT_READY` handler rather than from a frame of its own, so a single registration owns the event and the ordering below is explicit rather than left to dispatch order.
 
-**Window suppression via `OnShow`.** A plain `LootFrame:Hide()` on `LOOT_READY` is a no-op — the frame is not shown yet, and the default UI shows it on `LOOT_OPENED` with nothing to re-hide it, which is what produces the ~0.5s flash. Instead a one-time `HookScript("OnShow", …)` re-hides the frame the instant the default UI shows it, but only when `suppressLootWindow` is set. That flag is set to `not leftBehind` — true only when the pass took *everything*. Anything left behind (a lockbox we open by hand, or items skipped because bags filled mid-loop) keeps the window visible via an explicit `LootFrame:Show()`.
+**Window suppression runs through `OnShow`.** A plain `LootFrame:Hide()` on `LOOT_READY` is a no-op: the frame is not shown yet, the default UI shows it on `LOOT_OPENED`, and nothing re-hides it, which is the roughly half-second flash. Instead a one-time `HookScript("OnShow", ...)` re-hides the frame the instant the default UI shows it, but only while `suppressLootWindow` is set. That flag is `not leftBehind`, true only when the pass took *everything*. Anything left behind, a lockbox the player opens by hand or items skipped because bags filled mid-loop, keeps the window visible through an explicit `LootFrame:Show()`.
 
-**`suppressLootWindow` reset on `LOOT_CLOSED`.** Because `LOOT_READY` can be throttled, one corpse's "fully looted" verdict must not carry onto the next corpse's unlooted window. Core's `LOOT_CLOSED` handler calls `ns.ResetSpeedyLootWindow()` to clear it.
+**`suppressLootWindow` resets on `LOOT_CLOSED`.** Because `LOOT_READY` can be throttled, one corpse's "fully looted" verdict must not carry onto the next corpse's unlooted window. Core's `LOOT_CLOSED` handler calls `ns.ResetSpeedyLootWindow()`.
 
-**Master-looter stand-down.** When the player is the master looter (`lootMethod == "master"` and `masterLooterPartyID == 0`), Speedy Loot does nothing: threshold items flow through the ML window and calling `LootSlot` on one pops `MasterLooterFrame_Show` with no selection, which crashes on a nil `colorInfo` on some clients. Loot method is read through `GetLootMethodCompat`, which normalizes the legacy string API and the enum-returning `C_PartyInfo.GetLootMethod` (mapping enum `2` → `"master"` since `Enum.LootMethod` is nil on some Classic builds).
+**Master looter stands the whole pass down.** Master loot is a managed flow: at or above threshold, items are assigned through the ML window, and below it the group method hands them out, so there is nothing for Speedy Loot to take. Calling `LootSlot` on a threshold item also pops `MasterLooterFrame_Show` with no selection, which crashes on a nil `colorInfo` on some clients. `IsPlayerMasterLooter()` reads `C_PartyInfo.GetLootMethod()` and tests `method == LOOT_METHOD_MASTER (2) and masterLooterPartyID == 0`.
 
-**Bag-full safety.** Money and currency slots (`IsItemLootSlot` false) take no bag space and are always looted. Real item slots are only taken while `freeSlots > 0`; if general bags are full and real items wait, the pass loots nothing and leaves the window open so items can be taken by hand. Ignored items (`ns.IgnoreItems`) are left in the window with an `ITEM_OPEN_MANUALLY` notice (throttled to once per 5s per item).
+**Bag-full safety.** Money and currency slots (`IsItemLootSlot` false) take no bag space and are always looted. Real item slots are only taken while `freeSlots > 0`; if general bags are full and real items are waiting, the pass loots nothing and leaves the window open so items can be taken by hand. Only general-purpose bag space counts, by design: profession bags and quivers are ignored. Items on the Ignore List are left in the window with an `ITEM_OPEN_MANUALLY` notice, throttled to once per `ns.ITEM_ANNOUNCE_COOLDOWN` (5s) per item.
+
+**Auto Loot is respected, not overridden.** The pass runs only when `autoLootDefault` and `IsModifiedClick("AUTOLOOTTOGGLE")` disagree, which is the same rule the default UI applies: holding the auto-loot modifier inverts the setting. Repeat firings inside `ns.LOOT_DELAY` (0.25s) are dropped.
+
+## Lockboxes
+
+Two features share the **Lockboxes** options section, and both work the same way: a toggle (default on) plus a **Show for** scope of `"ROGUES"` or `"ALL"`, defaulting to Rogues only. A non-Rogue cannot pick a lock, so neither feature has much to say to them out of the box.
+
+Because three files ask that question, Core and Speedy-Loot for the notifications and Lockbox-Tooltips for the tooltip line, the predicates live in [Utilities.lua](Features/Utilities.lua) rather than in either feature: `ns.IsPlayerRogue`, `ns.LockboxTooltipsEnabled`, `ns.LockboxNotificationsEnabled`. A feature is on when its toggle is on **and** its scope either covers everyone or the player is a Rogue.
+
+### Lockbox Tooltips
+
+[Lockbox-Tooltips.lua](Features/Lockbox-Tooltips.lua) answers the question a locked box in the bag raises on its own: what skill does this need, and can I open it yet. It adds its own block, set off from the client's lines by a blank separator: the add-on's name, then `TOOLTIP_REQUIRES_LOCKPICKING_LABEL` or `TOOLTIP_YOUR_LOCKPICKING_LABEL` as an `AddDoubleLine` whose right column carries the number. Both labels are bare text, with the number passed as a separate argument rather than as a `%d` in the string. On a Rogue the row is green when their skill clears the box and red when it does not; a non-Rogue seeing it under the `"ALL"` scope gets neutral body colour. Read-only throughout: nothing casts, sends chat, or writes state.
+
+**The data.** `ns.LOCKBOX_SKILL_LEVELS` in [Data.lua](Data/Data.lua) maps item id to required skill, covering the `ns.AllowedItems` entries whose value is `false` minus four that have no number to give: **Thieven' Kit** (7868) is flagged Locked but publishes no skill number, **Floral Foundations** (39014) requires Inscription rather than Lockpicking, and **Dark Iron Lockbox** (208838) and **Scarlet Junkbox** (239248) are Season of Discovery rows that reach `ns.AllowedItems` through the name-guess merge rule rather than from a source carrying a skill number. A missing row means no tooltip line for that box, which is the deliberate trade: none of the four gets a line rather than being given a guessed one. The table's values are numbers and the tooltip formats them with `%d`, so a placeholder string here would error on hover.
+
+**Reading the player's skill.** `ns.GetPlayerLockpickingSkill` scans `GetNumSkillLines` and `GetSkillLineInfo` for the line whose name matches the localized name of the Lockpicking skill, because the skill lines are the only place the player's *current* rank lives. It returns nil for a non-Rogue, an untrained Rogue, or a client whose spell database did not answer, and every caller treats nil as unknown and falls back to neutral colouring instead of erroring.
+
+That localized name comes from **spell 1809**, the skill spell behind skill line 633. Its name *is* the skill line's name in whatever language the client is running, so one `GetSpellInfo` lookup answers in every locale, from the client's static database, before the player has trained anything. `ns.SPELLS.LOCKPICKING` carries the id and `ns.DIAGNOSTIC_API_CHECKS` probes the lookup, so a client that stopped answering shows as a FAIL row rather than as a silently neutral tooltip. `ns.GetSpellName` in [Utilities.lua](Features/Utilities.lua) reads both documented `GetSpellInfo` shapes, the classic multiple returns and the newer single info table, rather than betting on one.
+
+Two earlier sources are **deliberately not used**, and neither should come back:
+
+- The `LOCKPICKING` **global string**. Neither target client publishes it, and it FAILs in the API Endpoints report.
+- The client's own **"Requires Lockpicking (N)" tooltip line**, read through an `ITEM_MIN_SKILL` pattern. That was circular: Era never prints that line on a lockbox, so the name was never learned, the rank was always nil, and the requirement line stayed neutral white instead of green or red. The client's words cannot be the source for a name that is needed before the client has said anything.
+
+**Two duplicates, two different guards.** A tooltip can be re-processed without being cleared, so `TooltipHasText` looks for the branded header and bails, one check covering every line the block adds. Separately, some builds print their own requirement line, and repeating it would be noise, so `ClientStatesRequirement` matches the `ITEM_MIN_SKILL` format and switches the block to `TOOLTIP_YOUR_LOCKPICKING_LABEL` instead. That match is on the format string rather than on the skill's name on purpose: other add-ons print lines that name Lockpicking without stating a requirement, ATT's "World Drop > Lockpicking" breadcrumb among them, and a name match would read those as the client's line.
+
+**Which hook, and when it is installed.** `hooksecurefunc(GameTooltip, "SetBagItem", ...)`, unguarded: a widget method present on every client, firing for the bag and bank slots this feature is about. `TooltipDataProcessor.AddTooltipPostCall` would be the modern choice and is the wrong one here, because it does not exist on either target client and it hands over an item id with no bag or slot, so the still-locked check could not run on that path at all.
+
+The hook is installed from `PLAYER_LOGIN` rather than at file scope, and that placement is the whole ordering strategy. Post-hooks on `SetBagItem` run in the order they were registered, so registering after every other add-on has loaded puts our block last for free. A `SetBagItem` post-hook is also about as late as a synchronous add can be: the client's lines are set, `OnTooltipSetItem` has fired, and every add-on watching that script has had its say.
+
+**Deferring the add to the next frame is rejected outright.** `C_Timer.After(0)` does put the block under everything, and it strobes badly: a hovered bag button re-runs `SetBagItem` every frame, so the tooltip is rebuilt without the block, gets it a frame later, loses it on the next rebuild, and flickers for as long as the cursor rests on the item. A row out of place beats a tooltip that strobes. Do not reintroduce it, in any form that adds lines outside the build itself.
+
+### Why There Is No Click-to-Pick-Lock Gesture
+
+**Do not build this again without new evidence.** Twice the add-on carried a Shift + Right-Click gesture (originally Alt + Click) that put a `SecureActionButtonTemplate` over the hovered bag button with `macrotext` of `/cast Pick Lock` plus `/use <bag> <slot>`. Both times it came out again, because the click never reached the button.
+
+What was ruled out along the way, so nobody re-runs these experiments:
+
+- **The macro is correct.** Pasted into a real macro, `/cast Pick Lock` then `/use 0 5` picks the lock.
+- **Bag replacement add-ons are not the cause.** It failed with every bag add-on disabled, on the default bags.
+- **Frame stacking was addressed.** `HIGH` loses to the bags, which set their own frame levels; `TOOLTIP` clears them outright. It still did not fire.
+- **Tooltip ownership was addressed.** Reading `GameTooltip:GetOwner()` is unreliable when another add-on re-owns the shared tooltip; `GetMouseFoci` answers what the pointer is actually inside. It still did not fire.
+- **The strobe was a real and separate bug**, fixed on the way: hiding the overlay when the tooltip hid handed the cursor back to the bag button, which re-showed the tooltip, which re-raised the overlay, at frame rate.
+
+Two add-ons implementing this pattern, Locksmith and LazyLockBoxes, were read closely and their choices adopted (`TOOLTIP` strata, `GetMouseFoci`, restoring the tooltip from the overlay's `OnEnter`, a lockpick cursor). **Neither is confirmed working on Classic Era 1.15.x either.** The most likely explanation left is that the client no longer lets an add-on's secure button take a click over a bag slot, which is not something an add-on can work around.
+
+What ships instead is enough: the tooltip says what a box needs and whether the player clears it, `UNIT_SPELLCAST_SUCCEEDED` on Pick Lock rescans so a hand-picked box opens itself half a second later, and the mini-map lists what is still locked.
 
 ## Loot Sounds
 
-The rare-loot sound must fire only for loot pulled from a corpse, chest, or node — never for disenchanting, prospecting/milling, container opens, or the server's white-into-green merge, all of which travel the same `LOOT_OPENED` + `CHAT_MSG_LOOT` path. They are distinguished by the **loot source GUID**:
+The rare-loot sound must fire only for loot pulled from a corpse, chest, or node, never for disenchanting, prospecting or milling, container opens, or the server's white-into-green item merge, all of which travel the same `LOOT_OPENED` plus `CHAT_MSG_LOOT` path a corpse does. They differ only in the **loot source GUID**:
 
-- `CurrentLootFromWorldSource()` classifies the open loot window as `"world"` (a `Creature-`/`Vehicle-`/`GameObject-` source), `"item"` (every source is `Item-`), or `"unknown"` (source info not yet populated).
-- `StampWorldLoot()` — run on both `LOOT_READY` and `LOOT_OPENED`, because the GUID can populate on either and Speedy Loot may empty the slots between them — records `lastWorldLootAt` on `"world"`, clears it on `"item"`, and leaves it alone on `"unknown"` (a late-arriving world GUID must still be able to stamp, and a just-set stamp must survive an empty re-read).
-- `CHAT_MSG_LOOT` plays `ns.LOOT_SOUND_FILE` (`Includes/Sounds/Coin.ogg`, via `PlaySoundFile`) only if loot sounds are enabled, the stamp is within `ns.LOOT_SOUND_WINDOW` (1s), and the item link's color maps through `ns.QUALITY_COLORS` to a quality `>= ns.db.profile.lootSoundThreshold` (default `2`, Uncommon).
+- `CurrentLootFromWorldSource()` classifies the open loot window as `"world"` (at least one `Creature-`, `Vehicle-`, or `GameObject-` source), `"item"` (every resolved source is `Item-`), or `"unknown"` (the window is empty or the GUIDs have not populated).
+- `StampWorldLoot()` runs on both `LOOT_READY` and `LOOT_OPENED`, because the GUID can populate on either and Speedy Loot may empty the slots between them. It records `ns.state.lastWorldLootAt` on `"world"`, clears it on `"item"` so a disenchant cannot reuse a real corpse's window, and leaves it alone on `"unknown"`. That third state is kept distinct from `"item"` on purpose: a late-arriving world GUID must still be able to stamp, and a stamp just set for this corpse must survive an empty re-read.
+- `CHAT_MSG_LOOT` plays `ns.LOOT_SOUND_FILE` (`Includes/Sounds/item-pick-up.ogg`, through `PlaySoundFile`) only when loot sounds are on, the stamp is within `ns.LOOT_SOUND_WINDOW` (1s), and the item link's colour maps through `ns.QUALITY_COLORS` to a quality at or above `lootSoundThreshold` (default 2, Uncommon).
 
-## Pause / Resume & the Status Channel
+`ns.GetLinkQuality` reads quality off the link's colour because that is the only quality signal available without a `GetItemInfo` round trip. Heirloom shares Legendary's 5 so it always plays at any threshold; a colour the table does not carry, quest yellow for instance, returns nil, and each caller decides what unknown means. The loot sound stays quiet on it; a toast shows it anyway, because silently swallowing something the player did loot is the worse failure for a display.
 
-Auto-Opening pauses itself when bag space runs low, with hysteresis to avoid flapping: `ShouldPause` pauses below `ns.MIN_FREE_SLOTS` (4) but only resumes once free slots reach `MIN_FREE_SLOTS + 1`. The resume message therefore formats with `MIN_FREE_SLOTS + 1`, not `MIN_FREE_SLOTS`, so it does not promise a threshold that still leaves the player paused.
+### Pick Pocket
 
-A hard `UI_ERROR_MESSAGE` "inventory full" forces an immediate pause and plays a race/gender-specific "bags full" sound (`ns.RACE_SOUNDS`, falling back to `ns.BAG_FULL_SOUND_FALLBACK`), rate-limited by `ns.BAG_FULL_COOLDOWN` (10s).
+A rogue's pickpocket is the loot Speedy Loot hides most completely: it is mostly coin, which carries no quality, and its window is gone before it is seen. `pickPocketSound` plays **SoundKit 1183** (`PickupBag`) for it, and the two halves are deliberately split across two events:
 
-Status prints go through `ns.StatusPrint` ([Announcements.lua](Features/Announcements.lua)), which:
+- `UNIT_SPELLCAST_SUCCEEDED` for spell 921 only **arms** it, stamping `ns.state.pickPocketAt`.
+- `PlayPickPocketSound`, called from `LOOT_READY` and `LOOT_OPENED`, plays it only if a loot window with at least one slot opened within `ns.PICK_POCKET_LOOT_WINDOW` (1s) of that stamp, and disarms as it plays so one cast sounds once no matter how many loot events the window generates.
 
-- suppresses output during the **quiet window** (`ns.SetQuiet` / `IsQuiet`), raised on loading screens and login so transient churn stays silent;
-- dedupes an identical message within 5 seconds;
-- is held while an interaction frame is open — `AnnounceStatus` returns early if `IsInteractionActive`, and `OnInteractionClosed` flushes the held message after `ns.STATUS_FLUSH_DELAY` so a "Resumed" is not lost in the player's vendoring. `ns.state.announcedPaused` tracks what the player was last told.
+**The cast is not the confirmation.** Picking a target whose pockets are already empty fires `UNIT_SPELLCAST_SUCCEEDED` *and* a "your target has already had its pockets picked" error together, and yields nothing, so hanging the sound on the cast would announce a haul that does not exist. A pickpocket that comes up empty opens no window at all and the arming simply times out, which is the whole point.
 
-## Minimap Button
+`PlayPickPocketSound` **must be called before `ns.HandleSpeedyLoot`** in the `LOOT_READY` handler: Speedy Loot empties the slots, and an emptied window is indistinguishable from a pickpocket that found nothing.
 
-[Minimap-Button.lua](Features/Minimap-Button.lua) registers a LibDataBroker launcher and shows it through LibDBIcon-1.0. The icon swaps between `on` / `paused` / `off` textures (`ns.ICONS`) to mirror runtime state. Clicks: **left** toggles Auto-Opening, **right** toggles Speedy Loot, **middle** toggles Loot Sounds, **Shift+middle** opens the options panel (checked first).
+## Loot Toasts
 
-`showMinimap` (a profile setting) is the source of truth for visibility; the LibDBIcon `hide` field is kept inverted in sync. The minimap *position* lives in `ns.db.global.minimap` (account-wide, profile-independent), so switching or resetting a profile never moves the button — and `PLAYER_LOGIN` re-derives `hide` from `showMinimap` so a profile reset restores the button.
+[Loot-Toasts.lua](Features/Loot-Toasts.lua) is the answer to what Speedy Loot takes away. With the loot window hidden, the only record of a pickup is the chat log. When `lootToasts` is on, Core's `CHAT_MSG_LOOT` hands the link and message to `ns.ShowLootToast` after its own work, so the player's-own-loot prefix match is already done. Each toast is an icon, the coloured link, and a quantity. The newest sits at the anchor and older rows ride away from it, upward by default and downward when `lootToastGrowth` is `"DOWN"`.
 
-## Diagnostics Panel
+**On by default,** because shipping them on is what keeps hiding the loot window a net gain rather than a loss of information.
 
-[Diagnostics.lua](Features/Diagnostics.lua) generates bug-report text, not unit tests — WoW's sandboxed Lua has no assertion runner. Everything is read-only and side-effect free except the explicit Taint Log button, which sets the `taintLog` CVar. Reports build only on a button press. A single runtime toggle (`ns.diagnostics.enabled`, **not** a SavedVariable) gates the whole panel.
+**Because they ship on, the feature introduces itself.** A profile that has never dismissed the drag handle gets it raised at login through `ns.ShowLootToastIntro`, called from `PLAYER_LOGIN` and again from `ns.ApplyLootToastSettings` on a profile switch. The handle says what the feature is, previews where it will draw and how many rows it holds, carries the two gestures, and offers a **Disable Loot Toasts** button. Otherwise a new player's first contact with toasts is loot they did not ask for, drawn somewhere they did not choose.
 
-The probes: event log (bounded ring buffer, arguments snapshotted to escaped strings), event registration check (over `ns.EVENT_NAMES`), API endpoint existence checks (kept aligned with the guards in Utilities/Core/Speedy-Loot), a live loot-method report, installed add-on list, saved-variables dump, library versions, and the taint-log toggle. Diagnostics strings live in `ns.DiagnosticsStrings` and are intentionally **not** localized — they are developer-facing.
+`lootToastsIntroSeen` records the dismissal, and it is **per profile, not account-wide, on purpose**: a new or reset profile has not been introduced either, so it is shown the handle again. All three ways out set it, the right-click the handle advertises, its Disable button, and the panel's Lock button, since each is the player saying they have seen it. Nothing else raises the handle on its own: `ns.lootToastsUnlocked` starts nil, and beyond the introduction only `ns.SetLootToastsEnabled` and the panel's Unlock button lift it.
+
+**Eight kinds of item ignore the quality threshold**, each behind its own toggle, all on by default. For all eight the item's colour is a poor guide to whether the player cares, which is the whole reason the escape hatches exist. **They do nothing at the shipped threshold**, which is Poor and hides nothing at all; they exist for the player who raises it, and that is the moment a Common quest starter or a grey key would otherwise vanish.
+
+| Toggle | Test | Read from |
+| --- | --- | --- |
+| `lootToastContainers` | **presence** in `ns.AllowedItems` | table lookup |
+| `lootToastQuestItems` | `classId == 12`, **or** the tooltip says `ITEM_STARTS_QUEST` | `GetItemInfoInstant`, then a tooltip scan |
+| `lootToastRecipes` | `classId == 9` | `GetItemInfoInstant` |
+| `lootToastKeys` | `classId == 13` | `GetItemInfoInstant` |
+| `lootToastBags` | `classId == 1` **or** `11` | `GetItemInfoInstant` |
+| `lootToastMounts` | `classId == 15`, `subclassId == 5` | `GetItemInfoInstant` |
+| `lootToastPets` | `classId == 15`, `subclassId == 2` | `GetItemInfoInstant` |
+| `lootToastBindOnPickup` | `bindType == 1` | `GetItemInfo`, **14th return** |
+
+Three of those rows carry a trap worth naming:
+
+- **Bags are two classes, not one.** Quivers and ammo pouches are class 11, their own class rather than containers, a distinction the client's item database makes and a hunter does not. Both are the bag you were hoping would drop, so the Bags toggle covers the pair.
+- **Bags are not Containers.** Class 1 is the client's "Container", the thing loot goes *into*. The add-on's own openable containers are matched by id against `ns.AllowedItems`, never by class, and by presence rather than by a `true` value, so a still-locked box counts as much as an openable one. That row also earns its place differently from the rest: it is about the **add-on** being on the point of acting, not about the item.
+- **A quest starter is not a quest item.** `ITEM_STARTS_QUEST` rides with `lootToastQuestItems` because it is the same "do not walk away from this" case, but the class test misses it entirely, since a starter is as often an ordinary trinket or blade as it is class 12. Neither target client flags it in any API, so a tooltip is the only place the client will say so.
+
+**`AlwaysShown` tests them in cost order,** which is the order in the table above and deliberately not the order the panel lists them in. The table lookup is free, the `GetItemInfoInstant` reads answer from the client's own database with no cold-cache nil, Bind on Pickup needs the full `GetItemInfo`, and the quest-starter tooltip scan goes last because it is the only question that builds anything. That scan is affordable precisely because of where it sits: it runs only for loot every cheaper test has already passed on, and only for loot the threshold would otherwise have hidden. The panel's order is the player's: the catch-all first, the named kinds next, the two storage rows together at the end. `GetItemInfo`'s 14th-return position is the one assumption no type check would catch, so `ns.DIAGNOSTIC_API_CHECKS` probes it against the Hearthstone, which is Bind on Pickup and in every player's bag.
+
+**Quantity comes off the message, not the link.** The loot text carries an `x2` suffix; the link itself has no count. A single item has no suffix and renders as the plain name. The link's square brackets are stripped, since they are chat punctuation marking where a link starts and ends in running text and a toast is one item on its own line. The escape sequence is left intact so the text stays a real link rather than a lookalike.
+
+### Money
+
+**Coin is the only loot with no item behind it:** no link, no icon, no quality, so nothing the threshold or the always-shown kinds could ever have an opinion about. `lootToastMoney` gives it a toast on its own terms; without one, hiding the loot window leaves coin with no trace outside the chat log. It carries its own toggle for the same reason it needs a toast: every kill drops coin, so it is the row a player sees most often and the one they are most likely to want gone.
+
+Core's `CHAT_MSG_MONEY` hands the message to `ns.ParseMoney`, which reads the amount back out of the sentence by matching the client's **own** `GOLD_AMOUNT`, `SILVER_AMOUNT`, and `COPPER_AMOUNT` formats. That is what makes it work in a locale that does not call them gold, silver, and copper, and `ns.BuildFormatPattern` is what turns a format string into a pattern with captures. A unit the message does not mention simply does not match, which is the same as none of it.
+
+`ns.FormatMoney` renders `123g 02s 27c`: the largest unit the amount reaches, then every unit below it padded to two digits and nothing above it, so stacked toasts line up in one column while small change is not padded out with a leading `0g`. The suffixes are the client's own `*_AMOUNT_SYMBOL` globals, and the string **colours itself**, numerals in body white and each suffix in its own coin's colour from `ns.MONEY_PALETTE`. Those colours sit apart from `ns.PALETTE` because they are not the add-on's to choose: gold, silver, and copper look the way the client makes them look everywhere else, and splitting the colour at the letter is what lets the eye read the unit without reading the letter. Nothing wraps a colour around the result, which would flatten exactly that distinction. `ns.MoneyIcon` picks the coin pile by magnitude, `INV_Misc_Coin_02` at a gold or more, `_04` at a silver, `_06` below that, so the icon carries the size before the digits are read.
+
+### Frames, Layout, and the Handle
+
+**Frames are pooled, never leaked.** At most `lootToastMaxVisible` are live (1, 2, 3, 5, 8, 13, 21, or Unlimited, default 8). Unlimited is stored as the `ns.LOOT_TOAST_UNLIMITED` sentinel `0`, which `MaxVisible()` resolves to `math.huge`; the sentinel must never reach the cap arithmetic as a number, because `#active >= 0` is always true and would retire every row the instant it was drawn. Each toast fades after `lootToastDuration` seconds and returns to the pool, and the dwell is stamped onto the animation at play time rather than when the frame was built, because a pooled toast outlives any one choice of duration. The cap retires the **oldest** toast rather than dropping the new one: a burst of loot should show what just arrived, not freeze on the first rows.
+
+**Growth and alignment pick a corner between them.** `Restack` composes the two settings into one anchor point, `lootToastGrowth` supplying `TOP` or `BOTTOM` and `lootToastAlign` supplying `LEFT` or `RIGHT`, and pins each row corner-to-corner with the anchor there, ageing rows away along the growth axis only. The arithmetic is what makes both movements right: adding an entry raises the count, so every row already on screen gains exactly one step, while retiring the oldest drops the count and every survivor's index together, which cancels, so nothing near the anchor twitches to fill the gap left at the far end.
+
+**Every measurement is derived from the font size, and re-derived on every restack.** `Measure` owns both the row's size and its internal layout: the icon is `ICON_TO_FONT_RATIO` (1.5) times the font size, the gap a third of it, and the row's width ceiling `TEXT_WIDTH_RATIO` (32) times it, which is room for roughly 64 characters at any size. A fixed icon size was the bug: raise the font and the same icon shrinks against it. Running `Measure` from `Restack` rather than at creation is what lets a font, size, or alignment change reach toasts already on screen. Left-aligned the icon leads and the name runs right from it; right-aligned the icon trails and the name is justified back against it.
+
+**The flag string carries the weight**, because the client offers no bold. `SetFont`'s flag string is the only control over how heavy the glyphs land, and none of the shipped faces has a bold cut, so a thicker outline is what reads as heavier against a bright world background. `lootToastFontFlags` is one of `ns.LOOT_TOAST_FONT_FLAGS` (`"NONE"`, `"OUTLINE"`, `"THICKOUTLINE"`, `"MONOCHROME"`, `"MONOCHROMEOUTLINE"`, default `"OUTLINE"`), offered as a single Font Outline dropdown. `ResolveFlags` passes it through verbatim and turns only `"NONE"` into the empty string `SetFont` expects, and the flags ride both `SetFont` calls in `ApplyFont` so a face that fails to load keeps its weight on the fallback.
+
+**Fonts come from LibSharedMedia,** the registry ElvUI, Details, WeakAuras, and others publish into. Open Sesame ships the library so the dropdown is never empty: on its own it still registers the faces the client itself carries, and on a client running anything else that uses it the player gets that whole shared library. LSM also masks its list by locale, so a koKR client is only offered faces that can draw Korean. `DEFAULT` is the add-on's own sentinel rather than a registered face, resolving at runtime from `GameFontNormal`, which is the only correct answer on a locale whose client ships its own font; a face the library no longer knows falls back to the same place. `ns.GetLootToastFontChoices` rebuilds the list on every call rather than caching it, so a face registered by an add-on that loaded later still turns up the next time the dropdown opens.
+
+**The anchor is the fixed point rows stack from, and its size must not drift.** `TOAST_HANDLE_WIDTH` (400) and `TOAST_HANDLE_HEIGHT` (130) are fixed, never font-derived: rows anchor to a corner of the handle, so a size that moved with the font would walk the whole stack. The caption is three blank-line-separated rows, the add-on's name and the feature's in title gold, then the two gestures in body white in the order a player meets them, hung from the top of a `TOAST_HANDLE_LABEL_WIDTH` (260) column with the Disable button in the bottom corner at the same inset, so the button's edge lines up with the text's. `ApplyHandleLayout` pins both to **the end the rows do not use**: rows left-aligned puts the caption right, and the reverse, which is what stops the nearest row from being drawn over the caption and why the caption's side is derived from `lootToastAlign` rather than being a setting of its own. Body white rather than helper silver because those lines are the point rather than an aside to it, and they are read over open world at whatever the ground happens to be. There is no third line pointing at the options panel: the button says the same thing.
+
+**The handle locks itself.** The anchor is a `Button`: left-drag moves it, right-click locks it, and the caption says so, so a player who dragged it somewhere awkward does not have to find the Options Interface again. Turning the feature off also drops the handle, which would otherwise be stranded on screen with nothing to place.
+
+**Unlocking previews itself.** While the handle is up, `ns.RefreshLootToastSamples` stands in one "Example Item" sample per row the cap allows, a fixed 8 when the cap is Unlimited, each in a random quality at or above the Minimum Quality and wearing the colour-matched potion icon from `ns.LOOT_TOAST_SAMPLE_ICONS`. The preview does three jobs at once: where the stack sits and how many rows it holds, what the chosen font and size look like, and which tiers the threshold is letting through. Samples rebuild, and deliberately re-roll their qualities, on every appearance change, so each change visibly answers in the preview. They never fade, are released outright when the handle goes away, and come from the same pool, so cycling them allocates nothing.
+
+**The anchor position is account-wide.** `ns.db.global.lootToastPosition` sits alongside the Ignore List in `global`, because where a player wants this on their screen is not a per-character decision. `ns.ApplyLootToastPosition` runs on `PLAYER_LOGIN` and again from `ApplyProfile`; with nothing saved it defaults to centre plus 200, clear of the action bars and the chat frame.
+
+## Pause, Resume, and the Status Channel
+
+Auto-Opening pauses itself when bag space runs low. **Pause and resume share a single threshold**, `ns.MIN_FREE_SLOTS` (4): `ShouldPause` pauses below it and `IsSafeToOpen` resumes on reaching it, so `PAUSED_BAG_SLOTS` reports `ns.MIN_FREE_SLOTS` directly. The count the message promises is the count that actually resumes opening, and adding an offset to either side would break that.
+
+A hard `UI_ERROR_MESSAGE` inventory-full firing forces an immediate pause and plays a race and gender specific "bags full" voice line from `ns.RACE_SOUNDS`, falling back to `ns.BAG_FULL_SOUND_FALLBACK`, rate-limited by `ns.BAG_FULL_COOLDOWN` (10s). `ns.IsBagFullErrorID` is the only inventory-full test in the add-on: the handler and the Diagnostics event-log filter both classify `UI_ERROR_MESSAGE` through it, so a firing can never pause the add-on while the log files it away as uncorrelated noise. Never add a message-text match beside it, because the two would disagree exactly when a bug report needs the log line.
+
+Status prints go through `ns:StatusPrint` in [Announcements.lua](Features/Announcements.lua), which:
+
+- suppresses output during the **quiet window** (`ns:SetQuiet` and `IsQuiet`), raised on loading screens and on zoning so transient churn stays silent. `SetQuiet` only ever extends the window, never shortens it.
+- drops an identical message repeated inside `ns.STATUS_REPEAT_COOLDOWN` (5s).
+- is held while an interaction frame is open. `AnnounceStatus` returns early when `IsInteractionActive()` is true, and `OnInteractionClosed` flushes the held message after `ns.STATUS_FLUSH_DELAY` so a "Resumed" is not lost in the middle of the player's vendoring. `ns.state.announcedPaused` tracks what the player was last told, so the flush says the current state rather than replaying a stale one.
+
+Per-item notices use a separate throttle, `ns:AnnounceItemOnce`, which allows one message per item id per `ns.ITEM_ANNOUNCE_COOLDOWN` (5s). Both Ignore List notices share that stamp deliberately: a player who was just told Speedy Loot left an item behind does not also need to be told it will not be opened.
 
 ## Auto Loot Enforcement
 
-Speedy Loot and Auto-Opening both depend on the game's Auto Loot. `ns.EnsureAutoLoot()` sets the `autoLootDefault` CVar to `1` and prints `AUTO_LOOT_ENABLED` if it was off. It runs on profile apply, on the toggles that need it, and on world entry. The CVar accessors are picked by availability (`C_CVar.GetCVarBool` / `SetCVar` vs. the legacy globals).
+Speedy Loot and Auto-Opening both depend on the game's Auto Loot, and Open Sesame enforces it. `ns.EnsureAutoLoot()` reads `autoLootDefault` first and writes `1` only when it is off, then prints `AUTO_LOOT_ENABLED` naming the setting and its new state. It runs on profile apply, on world entry, and on each of the four toggles that need it (the two on the General panel and the two on the mini-map button).
+
+**This is the one enforced CVar the add-on ships without an opt-out toggle**, and that is deliberate: Open Sesame cannot do its job with Auto Loot off, so a toggle would only offer a way to break the add-on. Every other rule on an enforced write still binds: the write happens only on an actual change, the player is told through a `PrintMessage` notice naming the setting and its new state, and `README.md` discloses the behaviour in its Setup section. Keep that disclosure in place if the Setup copy is rewritten. The `taintLog` CVar in the Diagnostics panel is the only other CVar the add-on writes, and it is user-initiated rather than enforced.
+
+Every CVar read and write goes through the `C_CVar` namespace, never the bare globals, so there is no chance of an `or`-chained read falling through when Auto Loot is legitimately off.
+
+## Minimap Button
+
+[Minimap-Button.lua](Features/Minimap-Button.lua) registers a LibDataBroker launcher and shows it through LibDBIcon-1.0. The icon swaps between the `on`, `paused`, and `off` textures in `ns.ICONS` to mirror runtime state, and the broker's `text` field carries the same state in words for display add-ons. Clicks: **left** toggles Auto-Opening, **right** toggles Speedy Loot, **middle** toggles Loot Sounds, and **Shift + Middle-Click** opens the Options Interface, checked first in `OnClick` before any feature button. The combat refusal lives inside `ns:OpenOptionsPanel` and is never duplicated here.
+
+A **Locked Items** list leads the tooltip, directly under the title and above the feature blocks, drawn only when boxes are actually waiting. It is the one part that reflects the bags rather than a setting, so it is what the player opened the tooltip to check. It comes from `ns.GetLockedBoxes` in [Core.lua](Features/Core.lua): allowed-but-locked containers that are not on the Ignore List and still report `LOCKED`, collapsed to one row per distinct item with a stack count and **sorted by name**. Each line is the item's icon, then its name taken from the container's own item link, already localized and quality-coloured, with the brackets stripped since a tooltip line is not running text, and ` xN` appended only when more than one is held so no locale needs a plural form.
+
+It is computed on demand rather than cached: it runs once per tooltip render, not per frame, and a cache would need invalidating on every bag, trade, and pick-lock event. The scan stays cheap because `IsItemLocked` is reached only for ids `ns.AllowedItems` already marks as needing an unlock, so it costs a handful of reads rather than one per bag slot. Because the tooltip re-renders in place after a toggle click while the button still owns it, the list and the on/off states stay live.
+
+Both the button's position and its visibility live in `ns.db.profile.minimap`, the subtable handed straight to LibDBIcon. `hide` is the single source of truth for visibility, written by `ns:SetMinimapShown` and read by the options toggle, inverted for its "Enable" label. Under the Simple model this is profile state, so switching or resetting a profile changes it, and `ns:UpdateMinimapIcon` calls `LDBIcon:Refresh` with the live subtable on the profile callbacks so the change applies without a reload.
+
+## Options Panels
+
+Six panels, registered in [Options.lua](Options/Options.lua) in the order the house rules fix: **General** (root), then the feature panels **Notifications**, **Lockboxes**, and **Ignore List**, then **Profiles** second to last and **Diagnostic Tools** last. That order is the order of the `AddToBlizOptions` calls. The root panel keeps what does not belong to one feature: the welcome and mini-map toggles, `/Commands`, Auto-Opening, Speedy Loot, the four links, and the version line.
+
+**Registration is deferred, never at file scope.** `ns:RegisterOptionsPanels` is called from `PLAYER_LOGIN` immediately after `AceDB:New`, because the Profiles builder calls `AceDBOptions:GetOptionsTable(ns.db)` and `ns.db` does not exist earlier.
+
+**The opener routes by captured category id.** `AddToBlizOptions` returns `(frame, categoryID)`, and both are captured at the root panel's registration as `ns.GeneralPanel` and `ns.GeneralCategoryID`. `ns:OpenOptionsPanel` gates on combat, then calls `Settings.OpenToCategory(ns.GeneralCategoryID)`, then falls through to `AceConfigDialog:Open` as a last resort a correctly routed add-on never reaches. **Never look up the category by name:** passing the localized title returns nil on any client that has the Settings API, execution falls through to the dialog, and the panel appears as a floating window instead of docking. It breaks on TBC Anniversary while still working on Classic Era, so it survives testing on one flavor.
+
+**Sub-option rows are shared, not per-panel.** `ns.OptionsSubRow`, `ns.OptionsSubLabel`, and `ns.OptionsSubSelectRow` live in [Options-Utilities.lua](Options/Options-Utilities.lua). Three panels build sub-rows (General's Where and Group rules, Lockboxes' two scopes, Notifications' thresholds and appearance rows), so one shared shape is what keeps them from drifting apart. The three mechanical constraints still hold wherever they are built: one unnamed inline group per sub-option, control widths sized with slack rather than to an exact fit, and `hidden` on the group rather than on its members.
+
+Two panels size their sub-rows past the shared defaults, and both give back what they take: Notifications widens the caption to 1.4 for "Maximum Items to Display" and narrows its control to 0.9, and the bypass checkboxes take 2.4, which plus `ns.OPTIONS_SUB_INDENT_WIDTH` stays inside `ns.OPTIONS_ROW_WIDTH`.
+
+**The Ignore List panel registers its builder, not a built table**, so the list can redraw rows that did not exist at login. See [Panel and the Shared Item-List Builder](#panel-and-the-shared-item-list-builder).
+
+**The Profiles panel returns the stock AceDBOptions-3.0 table unmodified.** It is never mutated: `GetOptionsTable` does not return a private copy, so writing to the returned `args` would change every other Ace add-on's Profiles panel in the session.
+
+## Diagnostics Panel
+
+[Diagnostics.lua](Features/Diagnostics.lua) generates bug-report text, not unit tests. WoW's sandboxed Lua has no assertion runner, so everything here is environment probing and state capture. All of it is read-only and side-effect free except the explicit Taint Log button, which sets the `taintLog` CVar. Reports build only on a button press, never on load or on panel open.
+
+**The enable gate is runtime-only.** `ns.diagnostics` is a plain namespace table (`{ enabled = false, logging = false, log = nil }`) initialized at file scope and never persisted, so the panel starts off at every login and nothing survives a session. Off means off: with logging disabled the dispatcher's logging branch is a single boolean read before any allocation, and disabling the panel calls `ns:StopEventLog`, which releases the buffer. Every gated section hides on that one condition, so the panel defines local `SectionHeader` and `ReportOutput` builders that bake it in alongside shared `Hidden` and `Refresh` locals.
+
+The probes: **Event Log**, **Event Registration** (over `ns.EVENT_NAMES`), **API Endpoints**, **Loot Method**, **Other Add-ons**, **Relevant CVars**, **Display Context**, **Saved Variables**, **Library Versions**, the **Taint Log** control, and an **External Tools** section pointing at BugSack, `/console scriptErrors 1`, and `/etrace` rather than reimplementing them. Every report opens with the same client header: add-on version, client version and build, TOC, `GetLocale()`, and `WOW_PROJECT_ID`, so a pasted snippet always carries them. Reports are plain text with no colour escapes, which would paste as literal `|cff` codes.
+
+**The event log is bounded and snapshotted.** Entries go into a fixed buffer of the most recent 500 events, written before the real handler runs. `ns:LogEvent` converts each argument to a string immediately and never retains references, since some events carry frames or tables that would leak or go stale, and caps the argument count at 8 and each argument at 255 bytes, sized to hold a full loot line with its item link. **Pipes are escaped after the length cut**, so a truncated argument can never leave a dangling pipe that would eat the following separator.
+
+**Firehose traffic is counted, not dropped.** `ns.DIAGNOSTIC_EVENT_EXCLUDE` is empty and expected to stay that way: nothing Open Sesame registers is pure noise, since it listens on the coalesced `BAG_UPDATE_DELAYED` rather than raw `BAG_UPDATE`. `UI_ERROR_MESSAGE` is the one firehose, and it is only *sometimes* noise, because the inventory-full firing is exactly what the log needs. So it goes through the per-id filter instead: `ns.MESSAGE_ID_FILTERED_EVENTS` names the event and the argument position its message id arrives in, and `ns:SuppressUncorrelatedMessage` classifies each firing through `ns.IsBagFullErrorID`, the same call the live handler uses, so the filter cannot drift from it. Everything else folds into a per-id counter, first-seen text plus a count, rendered as one block at the end of the report with the biggest offender first. A firing carrying no numeric id in the filtered position is unclassifiable, and unclassifiable is signal: it logs verbatim. Filtering happens at capture rather than at render, because filtering at display time would still let spam push real events out of the buffer.
+
+**Two probes are Open Sesame's own context.** **Loot Method** prints the live return values and types of `C_PartyInfo.GetLootMethod`, plus the verdict Speedy Loot draws from them, because an existence check cannot prove the call returns the shape and enum number the master-looter stand-down is written against. **Display Context** answers "my loot toasts are off the edge of the screen" reports with the resolution and scale the saved anchor was chosen against, the saved point, and the live one; it reads the anchor through `ns.GetLootToastAnchorFrame`, which returns nil rather than creating the frame, so the report never brings a frame into existence as a side effect.
+
+**The saved-variables dump summarizes the Ignore List by length** rather than printing every row, and identifies it by table identity against the live list rather than by key name, so a rename cannot quietly turn the summary back into hundreds of rows. Recursion is capped at depth 8.
+
+Diagnostics strings live in `ns.DiagnosticsStrings` as plain English and are intentionally **not** localized, because they are developer-facing. The one localized string the panel reads is `ns.L["ADDON_TITLE"]`.
+
+## Regenerating the Item Tables
+
+**Two sources feed these tables, and neither is sufficient alone.** Each table carries its own regeneration notes in a block comment directly above it; this is the overview.
+
+| Source | Answers | Feeds |
+| --- | --- | --- |
+| **CMaNGOS (Wrath) world DB** | which containers exist, which kind they are, and why one belongs on the ignore list | `true`/`false` in `ns.AllowedItems`; membership and reason in `ns.DEFAULT_IGNORE_ITEMS` |
+| **Wowhead per-client openable listings** (Classic Era including Season of Discovery, Burning Crusade, Wrath) | which clients have an item | every expansion block and tag, plus roughly 128 rows the Wrath DB has never heard of |
+| **Maintainer decision** | the handful no rule reaches | 2 rows in `ns.DEFAULT_IGNORE_ITEMS`, marked `hand-added` in their comments |
+
+**Never rebuild either table from SQL output alone.** Doing so silently drops every modern Classic re-add and Season of Discovery container, resets every expansion tag, and loses the hand-added rows. The block above each table says exactly what its query does and does not produce.
+
+### The Two Tables Must Agree
+
+**Every Ignore List row must also be in `ns.AllowedItems` as `true`.** `BuildQueue` requires both, since the item has to be openable *and* not ignored. A row that is on the Ignore List but missing from `ns.AllowedItems` is a trap: the player removes it from the list expecting it to start opening, nothing happens, and there is nothing on screen to explain why. The same goes for a row `ns.AllowedItems` marks `false`, which would sit waiting on an unlock that is never coming.
+
+Their expansion tags have to agree too. Both come from the same Wowhead availability data, so a disagreement means one table was regenerated without the other, and the Ignore List would seed a row on a client whose `ns.AllowedItems` block does not carry the item.
+
+### What Each Source Is Load-Bearing For
+
+- **Expansion tags are Wowhead's, not the DB's.** The world DB records no expansion column, and id ranges do not work, because six-digit modern Classic re-adds sit alongside five-digit vanilla ids. In `ns.DEFAULT_IGNORE_ITEMS` the tag is *functional* rather than decorative: seeding only writes rows at or below `ns.currentExpansion`, so a wrong tag either hides a row from a client that has the item or offers one that can never resolve.
+- **The DB misses whole categories.** Clams and the Lotteryboxes deliver loot through a spell rather than `item_loot_template`, so the openable query never returns them.
+- **Loot references must be followed.** A container's real contents are frequently one `reference_loot_template` hop away, so the ignore-list query is recursive. On a reference row (`mincountOrRef < 0`) the `item` column carries no meaning, since it exists only to satisfy the primary key, so it is read as an item id **only** when `mincountOrRef` is positive.
+- **The raid branch ignores container bonding on purpose.** The DB has Blue Sack of Gems as Bind on Pickup while its four siblings are tradeable; that is a data quirk rather than a real difference, and filtering on it would drop the row.
+- **Unique is not a criterion.** An early ignore-list rule used `maxcount > 0` and produced 144 rows instead of 35, because nearly every quest item and one-off trinket is Unique.
+- **A re-added id inherits by name.** The Anniversary client renumbers items without changing what they are, so a re-added id takes the `true`/`false` of the existing row sharing its name. Failing that, a name carrying "Lockbox", "Junkbox", or "Locked Chest" is taken as needing an unlock; only two rows rest on that guess today.
+- **The Lockpicking skill number is in neither source.** `item_template.lockid` points into `Lock.dbc`, which is client data. Current values were read off each item's `warcraft.wiki.gg` page, and the comment above `ns.LOCKBOX_SKILL_LEVELS` carries a `-- TODO: Add SQL Query` marker plus a query listing which items *need* a value, for gap-checking after a regeneration.
 
 ## Saved Variables
 
-The single SavedVariables table is **`OpenSesameDB`** (declared in [Open-Sesame.toc](Open-Sesame.toc)), managed by AceDB-3.0.
+The single SavedVariables table is **`OpenSesameDB`**, declared in [Open-Sesame.toc](Open-Sesame.toc) and managed by AceDB-3.0. It holds every setting, the player's Ignore List, and the two saved positions.
 
-- **`profile`** — per-profile user settings: `autoOpen`, `speedyLoot`, `lootSounds`, `showWelcome`, `showMinimap`, `lockboxNotifications`.
-- **`global`** — account-wide, profile-independent state: `minimap` (the LibDBIcon position/`hide` subtable). Kept in `global` so switching or resetting a profile never moves the minimap button.
+Open Sesame uses the **Simple** saved-variables model: one shared `"Default"` profile for every character, with `true` as `AceDB:New`'s third argument. **Reset Profile therefore clears every setting back to install defaults, the mini-map button's position and visibility included, and leaves `ns.db.global` untouched.**
 
-### Migration Chain
+- **`profile`** carries every user setting: the Auto-Opening toggle and its Where and Group rules, Speedy Loot, the lockbox tooltip and notification toggles with their scopes, the loot sound and its threshold, the Pick Pocket sound, the Ignore List notifications toggle, the whole Loot Toasts block (enabled, threshold, the eight bypasses, money, duration, count, growth, alignment, font, size, flags, and `lootToastsIntroSeen`), `showWelcome`, and `minimap`, the LibDBIcon position and `hide` subtable.
+- **`global`** carries the two things that must not move with a profile: `ignoreList`, because which containers a player hoards is a decision about the items rather than the character, and `lootToastPosition`, because where a player wants the stack on their screen is not a per-character decision.
 
-There is one migration, run inline in `EventHandlers:PLAYER_LOGIN` immediately after `AceDB:New` (there are no numbered `MigrateXxx` functions):
+Defaults come from `ns.DATABASE_DEFAULTS` and are applied by AceDB-3.0 when a scope is first accessed, and explicit user values, including `false`, are never overridden. Note that scalar and table defaults are physically copied into the saved table (`copyDefaults` via `rawset`); only `*`/`**` wildcard defaults resolve through metatables.
 
-- **Flat → AceDB (remove after 2026-10-06)** — the pre-AceDB build stored each setting as a flat top-level key on `OpenSesameDB` and the minimap position at `OpenSesameDB.minimap`. AceDB leaves unknown top-level keys untouched, so the migration lifts the known flat keys into `ns.db.profile`, lifts the `minimap` table into `ns.db.global.minimap`, and clears the originals so leftover state can't shadow future edits.
+The one player-editable list is the Ignore List, and it follows the house default-list rule: `ns:SeedIgnoreList` rebuilds it from `ns.DEFAULT_IGNORE_ITEMS` only when the saved list is missing or empty, and Restore Defaults rebuilds it on demand. Shipping new default entries therefore does not change an existing player's list, so note additions in the release notes. `ns.AllowedItems` is a compile-time constant with nothing to re-seed.
 
-Defaults come from `ns.DATABASE_DEFAULTS` and are applied lazily by AceDB-3.0 via metatables — nothing is copied into the saved table, and explicit user values (including `false`) are never overridden.
+There is no migration chain. `PLAYER_LOGIN` clears three deprecated keys outright rather than converting them: `ns.db.global.minimap`, from before the subtable moved to the profile under the Simple model, and `lootToastFontOutline` and `lootToastFontBold`, which the single `lootToastFontFlags` dropdown replaced.
 
-There is no refill-on-empty logic: the openable/ignored item lists (`ns.AllowedItems`, `ns.IgnoreItems`) are compile-time constants in [Data.lua](Data/Data.lua), not saved variables, so there is no user-editable list to re-seed.
+**Profile switches, resets, and copies apply live.** All three AceDB callbacks are wired to `ApplyProfile` right after `AceDB:New`. It pushes the profile onto the runtime flags, re-runs `ns.EnsureAutoLoot` when either feature needs it, forces a scan, refreshes the mini-map icon, re-applies the toast position and settings, and calls `NotifyChange` for every registered panel so open options redraw. It is deliberately not called on initial login: `PLAYER_LOGIN` and `PLAYER_ENTERING_WORLD` own first-time setup and its ordering.
 
 ## Adding a New Openable Item
 
-1. Open [Data/Data.lua](Data/Data.lua) and find `ns.AllowedItems`.
-2. Add `[itemId] = true` for an item safe to open on sight, or `[itemId] = false` for a lockbox/locked chest that must be unlocked first.
-3. Place it in the correct expansion block (`01. World of Warcraft`, `02. The Burning Crusade`, `03. Wrath of the Lich King`) and keep the block alphabetized by the trailing `-- Item Name` comment.
-4. Nothing else to wire — `BuildQueue` reads the table directly.
+1. Open [Data/Openable-Items.lua](Data/Openable-Items.lua) and find `ns.AllowedItems`.
+2. Add `[itemId] = true` for an item safe to open on sight, or `[itemId] = false` for a lockbox or locked chest that must be unlocked first.
+3. Place it in the correct expansion block (`01. World of Warcraft`, `02. The Burning Crusade`, `03. Wrath of the Lich King`) and keep the block sorted by the trailing `-- Item Name` comment.
+4. For a `false` entry, add its required skill to `ns.LOCKBOX_SKILL_LEVELS` in [Data/Data.lua](Data/Data.lua) so the tooltip line has a number, or leave it out deliberately rather than guessing.
+5. Nothing else to wire. `BuildQueue`, `ns.GetLockedBoxes`, and the Loot Toasts Containers bypass all read the table directly.
 
-## Adding an Ignored Item
+## Adding a Default Ignored Item
 
-Add `[itemId] = true` to `ns.IgnoreItems` in [Data/Data.lua](Data/Data.lua). Speedy Loot will leave the item in the loot window with an `ITEM_OPEN_MANUALLY` notice instead of auto-looting it — used for items that are Unique, Bind on Pickup, temporary, or raid-boss drops.
+1. Add `[itemId] = { ns.VANILLA, "REASON" }` to `ns.DEFAULT_IGNORE_ITEMS` in [Data/Default-Settings.lua](Data/Default-Settings.lua), in the right expansion block with a trailing `-- Item Name` comment.
+2. The expansion tag is functional: seeding skips anything above `ns.currentExpansion`, so tag it with the earliest client that has the item.
+3. The reason is one of `RAID`, `QUEST`, `RECIPE`, `GEAR`, `HOLIDAY`, or `ITEM`, each mapping to an `OPTIONS_IGNORE_REASON_*` locale key. Do not invent a seventh without adding the key to `enUS.lua` and the mapping in [Features/Ignore-List.lua](Features/Ignore-List.lua).
+4. Confirm the id is in `ns.AllowedItems` as `true`, per [The Two Tables Must Agree](#the-two-tables-must-agree).
+5. The table is only a **seed**. Existing players keep the list they have, and the new entry reaches them through Restore Defaults or a fresh install, so note it in the release notes.
 
 ## Adding a New Registered Event
 
-1. In [Features/Core.lua](Features/Core.lua), add a handler: either `function EventHandlers:EVENT_NAME(...)` or an alias to an existing helper (`EventHandlers.EVENT_NAME = OnScanRequest`).
-2. That is the only step. The registration loop and `ns.EVENT_NAMES` (used by the diagnostics probe) are both derived from the `EventHandlers` table, so the dispatcher, the client-validity guard, and diagnostics all pick the new event up together.
+1. In [Features/Core.lua](Features/Core.lua), add a handler: either `function EventHandlers:EVENT_NAME(...)` or an alias onto an existing helper (`EventHandlers.EVENT_NAME = OnScanRequest`).
+2. That is the only step. The registration loop, the `C_EventUtils.IsEventValid` guard, and `ns.EVENT_NAMES` are all derived from the `EventHandlers` table, so the dispatcher and the diagnostics probe pick the new event up together.
+3. If the event is a firehose that is only sometimes signal, add it to `ns.MESSAGE_ID_FILTERED_EVENTS` with the argument position its message id arrives in, and extend `ns:SuppressUncorrelatedMessage` to allowlist the ids the add-on actually correlates. Never hand-maintain a denylist of noise ids.
 
 ## Localization
 
-Strings are localized through AceLocale-3.0. Locale files live in `Locales/<locale>.lua`, each registered with `NewLocale("Open-Sesame", "<locale>")`.
+Strings are localized through AceLocale-3.0. Locale files live in `Locales/<locale>.lua`, each registered with `NewLocale("Open-Sesame", "<locale>")`, and `Data/Data.lua` resolves `ns.L` once from the TOC's `ADDON_NAME` vararg for every other file to read.
 
-- **Source of truth** — [Locales/enUS.lua](Locales/enUS.lua) is the only file that passes the `true` default-fallback flag. Every key originates there; the other locales translate the same key set.
-- **Keeping locales in sync** — at runtime AceLocale falls back to English via `__index` for any missing key, so a locale can lag without crashing. Translating each `enUS.lua` key into every locale and keeping the files aligned is the job of the Localization pass — don't hand-edit the other locales during ordinary work.
-- **Placeholders** — `%s`/`%d` count, type, and order must match `enUS` per key in every locale, or `string.format` errors at runtime. Keys carrying format args here include `CHAT_LOADED` (`%s`), `PAUSED_BAG_SLOTS` (`%d`), `AUTO_OPENING_DESC` (`%d`), `ITEM_WILL_AUTO_OPEN` (`%s`), and `ITEM_OPEN_MANUALLY` (`%s`).
-- **Spanish** — esES and esMX are plain, fully translated `NewLocale` files, the same as every other locale. There is no shared Spanish `strings` table.
-- **Diagnostics strings are not localized** — `ns.DiagnosticsStrings` is developer-facing English only, kept out of `Locales/` entirely.
+- **Source of truth.** [Locales/enUS.lua](Locales/enUS.lua) is the only file that passes the `true` default-fallback flag. Every key originates there, and the other ten locales translate the same key set. At runtime AceLocale falls back to English through `__index` for any key a locale does not define, so a locale can lag without crashing.
+- **The Localization pass owns the other files.** Translating each `enUS.lua` key into every locale and keeping the files aligned is that pass's job. Do not hand-edit the other locales during ordinary work.
+- **Placeholders.** `%s` and `%d` count, type, and order must match `enUS` per key in every locale, or `string.format` errors at runtime. The keys carrying format arguments are `CHAT_LOADED` (`%s`), `PAUSED_BAG_SLOTS` (`%d`), `AUTO_OPENING_DESCRIPTION` (`%d`), `ITEM_WILL_AUTO_OPEN` (`%s`), `ITEM_IGNORED` (`%s`), and `ITEM_OPEN_MANUALLY` (`%s`).
+- **Renaming a key means renaming every call site with it.** A retired key name is never reused: AceLocale falls back to enUS only for keys a locale does not define, so a stale translation left under the old name would silently win.
+- **Diagnostics strings are not localized.** `ns.DiagnosticsStrings` is developer-facing English, kept out of `Locales/` entirely.
 
-WoW ships a fixed locale set and every supported locale file already exists (`deDE`, `esES`, `esMX`, `frFR`, `itIT`, `koKR`, `ptBR`, `ruRU`, `zhCN`, `zhTW`), so there is no "add a new locale" step — this is maintenance, not expansion.
+WoW ships a fixed locale set and every supported locale file already exists (`deDE`, `esES`, `esMX`, `frFR`, `itIT`, `koKR`, `ptBR`, `ruRU`, `zhCN`, `zhTW`), so there is no "add a new locale" step. This is maintenance, not expansion.
 
 ## Common Pitfalls
 
-- **Hiding the loot window on `LOOT_READY`**: a no-op — the frame isn't shown yet, so the default UI shows it afterward with nothing to re-hide it (the flash). Always suppress through the `LootFrame` `OnShow` hook gated by `suppressLootWindow`.
-- **Carrying a "fully looted" verdict across corpses**: a throttled `LOOT_READY` can reuse the previous corpse's `suppressLootWindow`. `LOOT_CLOSED` must reset it via `ns.ResetSpeedyLootWindow`.
-- **Looting while master looter**: calling `LootSlot` on a threshold item crashes on a nil `colorInfo` on some clients. The `lootMethod == "master" and masterLooterPartyID == 0` guard stands the whole pass down.
-- **Trusting `IsStealthed` alone**: Night Elf **Shadowmeld** does not always register through `IsStealthed`, so `IsPlayerStealthed` also scans buffs for the Shadowmeld aura (spell 20580). Auto-opening while stealthed would break stealth.
-- **Comparing the loot method enum to `"master"`**: `C_PartyInfo.GetLootMethod` returns a number, not the legacy string. Always go through `GetLootMethodCompat`, which maps enum `2` → `"master"`.
-- **`or` between two API *calls*** for compat fallbacks: falls through whenever the modern call legitimately returns `false` (e.g. auto-loot off). Select the function *reference* with `or` (Utilities.lua) or branch on availability with an `if` (Speedy-Loot.lua / Announcements.lua).
-- **Resume threshold off-by-one**: the pause hysteresis resumes at `MIN_FREE_SLOTS + 1`. The `PAUSED_BAG_SLOTS` message must format with `+ 1` or it promises a slot count that still leaves the player paused.
-- **Item-produced loot playing the rare sound**: disenchant/prospect/merge share the corpse loot path. Only a `"world"` GUID stamps `lastWorldLootAt`; never widen the stamp to `"unknown"`.
+- **A scan tooltip needs its owner set on every use, not once at file scope.** `IsItemLocked` hides `OpenSesameScanTooltip` when it is done, because setting a tooltip shows it and that one is anchored nowhere in particular. Hiding a tooltip drops its owner, and an **unowned tooltip accepts `SetBagItem` without complaint and populates nothing**, so every box reads as unlocked, the mini-map's Locked Items list quietly empties, and no tooltip line is added. `SetOwner` therefore runs at the top of every call. If that list goes missing while the boxes are plainly still in the bags, check this first.
+- **Matching `LOCKED` as a substring.** It is a short word, and other add-ons write tooltip lines that contain it without meaning it. `TooltipHasLine` compares whole lines.
+- **Hiding the loot window on `LOOT_READY`.** A no-op, because the frame is not shown yet, so the default UI shows it afterwards with nothing to re-hide it. That is the flash. Always suppress through the `LootFrame` `OnShow` hook gated by `suppressLootWindow`.
+- **Carrying a "fully looted" verdict across corpses.** A throttled `LOOT_READY` can reuse the previous corpse's `suppressLootWindow`. `LOOT_CLOSED` must reset it through `ns.ResetSpeedyLootWindow`.
+- **Looting while master looter.** Calling `LootSlot` on a threshold item pops `MasterLooterFrame_Show` with no selection, which crashes on a nil `colorInfo` on some clients. `IsPlayerMasterLooter()` stands the whole pass down.
+- **Comparing the loot method to `"master"`.** `C_PartyInfo.GetLootMethod` returns an enum **number**. Compare against `LOOT_METHOD_MASTER` (`2`); a string comparison reports "not master looter" forever.
+- **Trusting `IsStealthed` alone.** Night Elf Shadowmeld does not always register through it, so `IsPlayerStealthed` also scans buffs for the Shadowmeld aura (spell 20580). Opening a container while stealthed would break stealth.
+- **Item-produced loot playing the rare sound.** Disenchant, prospect, mill, container opens, and the white-into-green merge all share the corpse loot path. Only a `"world"` GUID stamps `lastWorldLootAt`; never widen the stamp to `"unknown"`.
+- **Adding an offset to the pause threshold.** Pause and resume share `ns.MIN_FREE_SLOTS`, and `PAUSED_BAG_SLOTS` reports it directly. A `+ 1` on either side makes the message promise a count that does not actually resume opening.
+- **Confusing the two ignore tables.** `ns.DEFAULT_IGNORE_ITEMS` stores `{ expansion, reasonKey }`; the saved list stores `true`. Seeding writes `true`, and the reason is looked up from the defaults table at read time, which is what lets better copy reach saved lists without a migration.
+- **Seeding a row this client cannot resolve.** An id above `ns.currentExpansion` never answers `GetItemInfo` here, so it sits in the panel as a bare number forever and keeps the refresh watcher armed for news that never comes. Both seeding and Restore Defaults filter by tag; the panel drops unresolvable ids again with `GetItemInfoInstant`.
+- **Registering a built options table where the builder is needed.** `RegisterOptionsTable(name, ns.BuildIgnoreListOptions())` freezes the Ignore List at its login contents. Pass the function.
+- **Letting the Unlimited sentinel reach the toast cap arithmetic.** It is stored as `0`, and `#active >= 0` is always true, so it would retire every row on sight. `MaxVisible()` resolves it to `math.huge` instead.
+- **Positioning a toast's name with `SetJustifyH` across a row-wide text box.** A row is far wider than its name, so justification alone decided where the name landed, and any row holding a stale justification drew its name at the opposite end of the row from its own icon. `Measure` sizes the text box to the string with `SetWidth(0)` and pins it to the icon, so placement is geometry rather than justification. Related: `SetFont` resets a font string's justification, so `ApplyFont` must run **before** `SetJustifyH`, never after.
+- **Releasing a pooled toast twice.** `fade:Stop()` can fire the group's own `OnFinished`, which releases again and pushes the frame into the pool a second time, after which one frame is handed out as two rows and a row silently vanishes. `ns.ReleaseLootToast` guards the pooling on `toast.pooled`, cleared by `AcquireToast`. The list removals in the same function are deliberately unguarded, because callers loop until a list shrinks and a release that removed nothing would spin forever.
+- **Re-adding a modern to legacy fallback.** The legacy globals are gone from both target clients, so an `or`-chained fallback is dead code that hides a real break. Call the namespaced API directly and add a row to `ns.DIAGNOSTIC_API_CHECKS`. See [Client Targets and API Surface](#client-targets-and-api-surface).
 
 ## Contributing
 
-- **Issues** — open them on the [GitHub Issues tab](https://github.com/Gogo1951/Open-Sesame/issues).
-- **Bug reports** — include game version + locale, class + level, repro steps, and relevant chat output. The Diagnostics panel (enable it, then run the relevant probe) generates a report header with all of the client/build/locale details.
-- **Discord** — [discord.gg/eh8hKq992Q](https://discord.gg/eh8hKq992Q).
-- **PR guidelines** — keep changes tightly scoped; match the surrounding code style; respect migration discipline (leave the dated flat→AceDB block until its removal date, and never hand-merge defaults around AceDB); keep placeholder counts aligned across locales; and update this document if the architecture or file map changes.
-- **Commit and PR descriptions require a User Story.** Don't just say "I changed X" or "I fixed Y." Frame the change in terms of who it helps and why:
+- **Issues.** Open them on the [GitHub Issues tab](https://github.com/Gogo1951/Open-Sesame/issues).
+- **Bug reports.** Include game version and locale, class and level, repro steps, and the relevant chat output. Enabling the Diagnostics panel and running the relevant probe produces a report whose header already carries the client, build, TOC, locale, and project id.
+- **Discord.** [discord.gg/eh8hKq992Q](https://discord.gg/eh8hKq992Q).
+- **PR guidelines.** Keep changes tightly scoped. Match the surrounding code style, which is StyLua's default output. Never hand-merge defaults around AceDB, and never write `db.field = db.field or default`, which overwrites an explicit `false`. Keep placeholder counts aligned across locales. Update this document in the same change if the architecture, the file map, or the saved-variables shape moves. Open Sesame prints to the player only and sends no chat, so the 255-byte `SendChatMessage` ceiling does not currently bind any string here; adding a sent message brings that check into scope for every locale, and the widest-encoding locale is the one to test against.
+- **Commit and PR descriptions require a User Story.** Do not just say "I changed X" or "I fixed Y". Frame the change in terms of who it helps and why:
 
   **Format:** *As a [role], I [needed / wanted] [behavior] so that [outcome]. This change [does X].*
 
-  **Example:** *As a rogue trading locked boxes to a guildmate to crack, I wanted the boxes to open on their own once unlocked without waiting on a bag event. This change adds a second forced rescan after `TRADE_CLOSED` on the pick-lock settle delay.*
+  **Example:** *As a rogue trading locked boxes to a guildmate to crack, I wanted the boxes to open on their own once unlocked rather than waiting on a bag event. This change adds a second forced rescan after `TRADE_CLOSED` on the pick-lock settle delay.*
 
-  The User Story makes review faster and gives future maintainers context the diff alone won't carry.
-
-## Guide Feedback
-
-Generated on 2026-07-08 after performing README-Technical generation on Open Sesame.
-
-- **Drop the Spanish shared-`strings`-table rule (maintainer-confirmed).** The guide's Localization section says *"esES/esMX use the style guide's shared-`strings`-table pattern; reference it rather than duplicating strings."* Spanish locales are no longer shared — [Locales/esES.lua](Locales/esES.lua) and [Locales/esMX.lua](Locales/esMX.lua) are plain, fully translated `NewLocale` files like every other locale (verified: no `strings` reference in any locale file). Suggested edit: delete the Spanish bullet from the guide (and the corresponding note in the Style Guide), since it now documents a pattern the codebase doesn't use and will otherwise be re-flagged every run.
-- **Remove "Adding a New Locale" from the guide and the live references (maintainer-confirmed).** The guide already treats localization as maintenance-not-expansion, but the live reference [Connoisseur/README-Technical.md](https://github.com/Gogo1951/Connoisseur/blob/main/README-Technical.md) still ships an `## Adding a New Locale` section, so a future run that copies the reference structure will reintroduce it. Suggested edit: drop the `## Adding a New Locale` section from the Connoisseur and Water-Dispenser references so the guide and references agree.
+  The User Story makes review faster and gives future maintainers context the diff alone will not carry.

--- a/README-Testing.md
+++ b/README-Testing.md
@@ -1,0 +1,97 @@
+# Open Sesame // Manual Test Plan
+
+This is the manual test plan for Open Sesame, the steps to confirm it works before a release is tagged. For what it does, see [README.md](https://github.com/Gogo1951/Open-Sesame/blob/main/README.md); for how it works, see [README-Technical.md](https://github.com/Gogo1951/Open-Sesame/blob/main/README-Technical.md).
+
+## Before you start
+
+**Run the whole list on Classic Era, then `/reload` and run it again on TBC Anniversary.** Steps are numbered continuously so you can report "failed on step N."
+
+Gather these once so you aren't caught short mid-run:
+
+- **Both flavors installed** — Classic Era and TBC Anniversary. The add-on ships for both, and a run on one flavor is half a run.
+- **A Rogue with Lockpicking trained.** Steps 7, 13 and 19 need one. Any skill level works — a rank far below what a box asks for is as useful a result as a rank above it.
+- **A non-Rogue character**, any class, for step 8.
+- **Openable containers in your bags** — clams are the easiest to come by (Small Barnacled Clam, Big-mouth Clam, Thick-shelled Clam), from fishing or murloc drops. Bring several; the add-on opens them as fast as you can stock them.
+- **A locked box in your bags** — a Battered, Worn or Sturdy Junkbox from pickpocketing, or any Lockbox fished up or looted from humanoids. Bring two of the same kind if you can, for the stack count in step 9.
+- **Something to kill and loot repeatedly**, for coin, greens, and a common drop you can farm (cloth, a grey trinket). Humanoids give you all of it at once.
+- **Bag space you can fill and empty on demand** — vendor trash you're willing to carry, so you can drop below four free slots and climb back out.
+- **A dungeon entrance you can zone into**, for step 10. You don't have to clear anything; walking in and back out is the whole test.
+- **A non-English client** — only for the optional spot-check in step 24.
+
+Unless a step says otherwise, be **out of combat, out of instances, and not stealthed**, with no vendor, mail, bank or trade window open. Every step in this plan works solo.
+
+This plan deliberately skips the Loot Toasts appearance settings (font, size, outline, grow direction, alignment, seconds on screen, maximum rows, minimum quality, and the nine Always Show toggles), the Group hold-off, and the contents of the Loot Method, Relevant CVars and Display Context reports beyond confirming they produce text. Those are settings you judge by eye. The steps below cover the paths that break silently.
+
+## Verify this release's changes
+
+This release adds Loot Toasts, the Ignore List, Lockbox Tooltips, the Locked Items list on the mini-map tooltip, and the Auto-Opening Where hold-off; it moves the mini-map button from account-wide storage onto the profile, and narrows the loot sound to loot that came off a corpse or out of a chest. These thirteen steps are the ones that prove it.
+
+**Loot Toasts**
+
+**1.** Log in for the first time on this build. A dark panel must appear above the centre of your screen reading **Open Sesame Loot Toasts**, with the lines *"Click + Drag to Position"* and *"Right-Click to Lock"* and a **Disable Loot Toasts** button, and a stack of sample rows reading **Example Item** in assorted item colours with matching potion icons. Failure is no panel at all, a panel with no sample rows, or a panel with no way out of it — the feature ships turned on, so this introduction is the only warning a player gets before loot starts drawing on their screen.
+
+**2.** Left-click and drag the panel somewhere you want it, then **right-click it**. The panel and its samples must vanish on the spot. Now go kill something and loot it. Rows must appear where you left the panel — the item's own icon, its name in its quality colour, an ` x2` suffix on a stack of more than one — and fade away on their own after about five seconds. Coin must get its own row, with a coin icon and an amount reading like *"1g 24s 07c"*. Failure is rows drawing in the old position or in the screen centre, rows that never fade, no row for coin, or the item name arriving as a bare number.
+
+**3.** Type `/reload`. The introduction panel must **not** come back, and the next thing you loot must toast in the position you chose. Then open **Options → AddOns → Open Sesame → Notifications**, scroll to Loot Toasts, and click **Reset Position** — the panel's rows must return to the middle-top of the screen. Failure is the introduction reappearing on every reload (it is meant to be shown once per profile), or a position that resets itself.
+
+**Ignore List**
+
+**4.** Open **Options → AddOns → Open Sesame → Ignore List**. It must list shipped containers as real item links with icons, sorted by name, each with a red "no entry" note in its tooltip explaining why it's on the list. Failure is rows showing as bare item numbers that never resolve into names, or an empty list. **The list is longer on TBC Anniversary than on Classic Era by design** — containers a client has never heard of are left off it, so the two flavors are meant to differ here.
+
+**5.** Pick a common thing you can farm — cloth, a grey drop — and add it: paste its item link (or its item ID) into the **Add Item** box and press Enter. It must appear as a row immediately. Now go kill something that drops it. Speedy Loot must **leave that item sitting in the loot window** for you to take by hand, and your chat must read *"[Item] was left in the loot window for you to open yourself."* Failure is the item being looted anyway, or being left behind with no explanation in chat.
+
+**6.** Drop a clam into your bags and add **that** to the list too. It must sit in your bags **unopened** for as long as it's on the list. Then click **Restore Defaults** and confirm the prompt. Both items you added must be gone, the shipped rows must all be back, and the clam in your bags must now open on its own within a second or two. Failure is a clam that opens while it's on the list, a Restore Defaults that fires with no confirmation prompt, or one that leaves your own additions behind.
+
+**Lockbox Tooltips**
+
+**7.** On your Rogue, hover a locked box in your bags. Below the client's own lines there must be a block headed **Open Sesame** carrying a Lockpicking number — either *Requires Lockpicking* with what the box needs, or *Your Lockpicking* with the rank you have — coloured **green when your skill clears the box and red when it doesn't**. **Which of the two lines you get depends on the client**: the flavor that prints its own "Requires Lockpicking" line gets *Your Lockpicking* instead, so run this on both and expect them to differ. Failure is no block on a Rogue who plainly has the skill, both lines at once, or a colour that disagrees with the numbers.
+
+**8.** Hover the same kind of box on your non-Rogue. There must be **no Open Sesame block at all** — the feature is set to Rogues only out of the box. Now open **Options → AddOns → Open Sesame → Lockboxes** and set **Show for** to **For All Characters**, then hover again: the requirement line must appear, in neutral white, with no rank of your own beside it. On the flavor that already prints its own requirement line there is deliberately nothing left to add and no block appears — that is correct, not a failure. Failure is a block showing on a non-Rogue while the setting still reads For Rogues.
+
+**Locked Items on the mini-map tooltip**
+
+**9.** With at least one locked box in your bags, hover the mini-map button. Above the Auto-Opening block there must be a **Locked Items** heading listing each waiting box — its icon, its name in the item's own colour, and an ` x2` count when you're carrying more than one of the same box. Have the Rogue pick one open and hover again: that row must be gone. Failure is the list missing while a locked box is plainly in your bags, a row that persists after the box is opened, or the list appearing with no locked boxes at all.
+
+**Auto-Opening: Where**
+
+**10.** Left-click the mini-map button to turn **Auto-Opening off**, put a clam in your bags, and walk into a dungeon. Open the main panel, set **Where** to **Outside Instances**, then turn Auto-Opening back on. The clam must stay shut for as long as you're inside. Walk back out — it must open on its own within a couple of seconds, with no bag click and no reload. Failure is the clam opening inside the instance, or staying shut after you leave.
+
+**Mini-map button now lives on the profile**
+
+**11.** On the main panel, untick **Enable Mini-map Button**. The button must disappear immediately. Now go to **Profiles** and click **Reset Profile**. The mini-map button must come back **on its own, without a `/reload`**, and the Enable Mini-map Button box must show ticked again the moment you click back to the main panel. Failure is the button staying hidden until you reload, or the checkbox disagreeing with what's on your mini-map.
+
+**Loot sound narrowed to corpse and chest loot**
+
+**12.** With Loot Sounds on, kill mobs until an Uncommon (green) or better drops. A single chime must play as it lands. Then have your Rogue open a junkbox, or open a clam, that yields a green: **no chime may play**, because that item came out of a container rather than off a corpse. Failure is a chime on box or clam contents, a chime on a white or grey item off a corpse, or no chime at all on a green off a corpse.
+
+**Pick Pocket sound**
+
+**13.** On your Rogue, stealth up and pickpocket a humanoid that has something in its pockets. A bag-rustle sound must play once as the loot arrives. Pickpocket the same target again, now that its pockets are empty: the cast succeeds and **nothing may sound**. Failure is silence on a successful pick, a sound on an already-picked target, or the same pick sounding twice.
+
+When steps 1–13 pass on both flavors, this release's changes are verified. Run the rest of the plan, then proceed to `4 - Pre-Launch Review Prompt.md`.
+
+## Core checks
+
+**14.** Log in with Open Sesame enabled. No Lua error window may appear and no red error text may print. A welcome line must print, coloured, in the shape *"Open Sesame // Version … Settings … can be found under Options > AddOns > Open Sesame."* — reading a real dated version in a packaged build, or **Dev** in an unpackaged working copy. If your Auto Loot setting was off, one extra line reads *"Auto Loot has been enabled. Open Sesame requires it to function."*, which is correct. Then type `/reload`: the UI must come back clean and the welcome line must print again. Failure is any error naming Open Sesame, a missing or uncoloured welcome line, or a line containing `nil` or a stray `%s`.
+
+**15.** Open the settings three ways: type **`/os`** (the add-on's only slash command), **Shift + Middle-Click** the mini-map button, and press `Esc` → **Options** → **AddOns** → **Open Sesame**. All three must land you in the same place: the settings **docked inside the Blizzard Options window**, with Open Sesame selected in the category list on the left and five entries beneath it in this order — **Notifications**, **Lockboxes**, **Ignore List**, **Profiles**, **Diagnostic Tools**. Failure is nothing happening, or a standalone window floating free of the Options frame. **TBC Anniversary is the flavor that historically breaks this**, so a tester who ran only Era has not finished this step.
+
+**16.** Pull a mob, and while still in combat type **`/os`**, then Shift + Middle-Click the mini-map button. Each must print *"As a safety precaution, the Options Interface cannot be opened during combat."* and the panel must **not** open. Kill the mob and stand still: the panel must not open by itself once combat ends. Failure is the panel opening, silence with no message, or a red `ADDON_ACTION_BLOCKED` error naming Open Sesame.
+
+**17.** Hover the mini-map button and read its three keybind lines, then try each. **Left-Click** must toggle Auto-Opening, **Right-Click** must toggle Speedy Loot, **Middle-Click** must toggle Loot Sound. After each click the tooltip must re-draw in place with that feature's state flipped between **Enabled** and **Disabled**, and the button's icon must follow Auto-Opening: green bag on, red bag off, black bag paused. Failure is a click doing something other than what its line says, a state that doesn't update until you move the cursor away, or an icon that disagrees with the tooltip.
+
+**18.** With Auto-Opening on, put several clams in your bags. They must open one after another with no clicks from you, over a second or two. Now fill your bags until you have **fewer than four free slots**: chat must read *"Auto-Opening is Paused until you have at least 4 empty bag slots."*, the mini-map icon must go black, and nothing more may open. Free a slot: chat must read *"Auto-Opening has Resumed."* and the remaining clams must open. Failure is clams sitting unopened with slots to spare, opening while paused, or a pause message that never resolves into a resume.
+
+**19.** Loot a locked box on your Rogue. Chat must read *"[Box] will be automatically opened once it's unlocked."* — on a non-Rogue this message is deliberately silent unless you set **Lockboxes → Show for** to For All Characters. Now pick the box open. It must open itself and hand you its contents within a second or so of the lock coming off, with no second click from you. Failure is the box sitting there unopened after it's unlocked, or the notice naming the wrong item.
+
+**20.** With Speedy Loot on, loot a corpse. The loot window must **never appear at all** — not even a flash — and everything, coin included, must land in your bags. Now fill your bags completely and loot a corpse holding real items: the loot window must **stay up** with those items still in it, so you can take them by hand. Failure is a loot window flashing for half a second on every corpse, or a window hidden while loot is still stranded in it.
+
+**21.** With a clam in your bags, try each of these in turn: pull a mob and fight, sit down and eat or drink, and open a vendor or mailbox window. **Nothing may open** in any of the three. Then leave combat, stand up, and close the window — the clam must open on its own within a second or two. Failure is a clam opening mid-fight, opening while a merchant window is up, or never opening once you're clear.
+
+**22.** Read the add-on's chat lines back — the four you've now seen, about a box waiting to be unlocked, an item left in the loot window, an item on your Ignore List, and Auto-Opening pausing. Every one must be branded **Open Sesame //**, read as one complete sentence, and carry a **clickable item link** where an item is named, with the count in the pause line reading as a real number. Nothing this add-on prints is ever sent to another player, so nothing here should show up in any chat channel. Failure is `nil` or a stray `%s` or `%d` in a line, a raw `|cff…|Hitem:` sequence showing as text instead of a link, or the same line repeating over and over as your bags update.
+
+**23.** Open **Diagnostic Tools**. Only the warning paragraph and the **Enable Diagnostic Tools** toggle may be visible, and the toggle must be **off**. Tick it: eleven sections must appear without reopening the panel — Event Log, Event Registration, API Endpoints, Loot Method, Other Add-ons, Relevant CVars, Display Context, Saved Variables, Library Versions, Taint Log, and External Tools. Click **Start Event Log**, then go fill your bags and loot something so the game tells you your inventory is full, and also spam an ability off cooldown a dozen times so the game prints red combat errors that have nothing to do with looting. Come back and click **Show Captured Events**. The inventory-full firing must appear as a **full timestamped line**; the combat errors must **not** appear as individual lines but as counted rows in the block at the end reading **"Suppressed uncorrelated traffic:"**, one row per error in the shape `UI_ERROR_MESSAGE(56, Ability is not ready yet.) x12`. Click each remaining report button in turn — every one must fill its box with readable text rather than an error or a blank. Untick the toggle: everything below it must vanish at once. Then `/reload` and reopen the panel — the toggle must be **off** again, because diagnostics never persists between sessions. Failure is the gate on by default, combat spam flooding the log as individual lines, the inventory-full firing being swallowed into the summary, or diagnostics surviving a reload.
+
+**24.** *Optional, and only worth running on a non-English client.* Log in on one and open every panel. Every label, description and note must render in that language — failure is a raw key like `OPTIONS_ENABLE_LOOT_TOASTS` or `LOCKBOXES_DESCRIPTION` showing on screen instead of words. Then trigger the pause message and an item message: the number and the item name must land inside sensible sentences, with no `nil` and no leftover `%s` or `%d`. Loot coin and read the money toast — the amounts must carry that client's own gold, silver and copper symbols. Finally, hover a locked box on a Rogue: the Lockpicking block must name the skill exactly as that client spells it. **That last one is the highest-risk check here** — the skill name is read from the client rather than translated by the add-on, and when it doesn't match, the block simply never appears, with no error to warn you.
+
+When every step passes on both Classic Era and TBC Anniversary, manual testing is complete. Proceed to `4 - Pre-Launch Review Prompt.md`.

--- a/README.md
+++ b/README.md
@@ -1,48 +1,70 @@
 # Open Sesame
 
-Automatically open clams, lockboxes, and unlocked containers in your bags, no clicking required. Built-in Speedy Loot hides the loot window for near-instant auto looting. Less time clicking, more time playing.
+Automatically open clams and unlocked containers in your bags, no clicking required. Built-in Speedy Loot hides the loot window for near-instant auto looting, and Loot Toasts show every pickup so your eyes stay on the fight. Fast, efficient looting.
+
+TL;DR: Kill stuff. Loot stuff. Skip the clicking. Keep killing. Loot more, faster.
 
 <img width="360" src="https://github.com/user-attachments/assets/48e86839-798f-4086-82d1-bcf9c23dc1eb" />
 
 ## Features
 
-📦 **Auto-Opening** // Opens clams, lockboxes, and unlocked containers in the background — no clicks required.
+📦 **Auto-Opening** // Opens clams, sacks, crates, and unlocked containers in the background, no clicks required, and always respects your Ignore List.
 
-🔐 **Locked Items** // Loot a lockbox and Open Sesame queues it up — the moment it's unlocked, it pops open automatically.
+🔐 **Locked Items** // Hover a lockbox to see the Lockpicking skill it needs and whether yours clears it. Once unlocked, it pops open automatically.
 
 ⚡ **Speedy Loot** // Hides the loot window so you can pick up loot near-instantly.
 
-🔊 **Loot Sounds** // Plays a distinct sound when you loot an Uncommon or higher quality item. Can be turned off.
+🔊 **Loot Notifications** // On-screen toasts log every pickup, and a distinct sound plays for the good stuff. Both are yours to tune, or turn off.
 
-🦺 **Safety First** // Combat, casting, low bag space, Bind on Pickup, Unique, and raid-boss items are all skipped automatically — your bags stay protected.
+🦺 **Safety First** // Combat, casting, low bag space, Bind on Pickup, and raid-boss containers are all skipped automatically. Your bags stay protected.
 
 ## Setup
 
 1. Install the add-on, ideally using [CurseForge](https://www.curseforge.com/wow/addons/open-sesame) or [Wago](https://addons.wago.io/addons/open-sesame).
-2. Make sure Auto Loot is enabled in your game settings — Open Sesame needs it to function.
-3. Log in. Open Sesame starts working immediately, no setup required.
-4. Left-click the minimap button to toggle Auto-Opening, right-click for Speedy Loot, middle-click for Loot Sounds.
-5. Frankly, my dear, I don't give a clam.
+2. Log in. Open Sesame switches Auto Loot on for you, since it can't work without it, and starts opening straight away.
+3. Go kill something. Your bags will be tidier than when you started.
+4. Left-click the mini-map button to toggle Auto-Opening, right-click for Speedy Loot, middle-click for Loot Sounds.
+5. Type `/os` to fine-tune: where Auto-Opening runs, how Loot Toasts look, and which containers to leave alone.
+6. *"Frankly, my dear, I don't give a clam."*
 
 ## How It Works
 
-### Minimap Button
+### What Gets Opened, and What Does Not
+
+- **Opens on sight** // Clams, coin purses, sacks, crates, and anything else that needs no key. Nearly 500 containers, matched by item ID.
+- **Waits on locked boxes** // Open Sesame can't pick a lock, so a lockbox still needs a rogue or a key. Once it's unlocked, it opens on its own.
+- **Pauses when bags get tight** // Auto-Opening stops below four free slots and resumes once you make room.
+- **Skips your Ignore List** // Seeded with the containers usually worth more sealed, like raid gem sacks and crates holding Bind on Pickup gear.
+- **Stands down** // In combat, mid-cast, stealthed, or at a vendor, mailbox, bank, auction house, or trade window. Speedy Loot also steps aside under master loot.
+
+### Mini-Map Button
 
 | Action | Effect |
 | --- | --- |
+| Hover | Show every feature's status, plus the locked boxes waiting in your bags |
 | Left-click | Toggle Auto-Opening on or off |
 | Right-click | Toggle Speedy Loot on or off |
 | Middle-click | Toggle Loot Sounds on or off |
+| Shift + Middle-click | Open the Options Interface |
 
 ### Slash Commands
 
 | Command | Effect |
 | --- | --- |
-| `/os` | Open the Open Sesame options panel |
+| `/os` | Opens the Options Interface for this add-on |
+
+### Options
+
+- **Open Sesame** // Welcome message, mini-map button, and the master switches for Auto-Opening and Speedy Loot. Auto-Opening can be limited to outside instances, or to solo play.
+- **Notifications** // The loot chime and its minimum quality, a separate Pick Pocket chime, and every Loot Toast setting: position, font, size, duration, and which pickups always show.
+- **Lockboxes** // Tooltip skill lines and chat notices, shown to rogues only or to every character.
+- **Ignore List** // Drag in an item, or paste a link or item ID, to leave it alone for good. Shared across your characters, with one-click restore of the defaults.
+- **Profiles** // The standard profile controls.
+- **Diagnostic Tools** // Everything a bug report needs, ready to copy.
 
 ## Testing & Localization Status
 
-🟢 World of Warcraft Classic (🟡 Season of Discovery) // WoW 1.15.8
+🟢 World of Warcraft Classic (🟡 Season of Discovery) // WoW 1.15.9
 
 🟢 Burning Crusade Anniversary // WoW 2.5.6
 
@@ -56,18 +78,18 @@ Please reach out if you would like to be involved!
 
 ## Links
 
-* [GitHub](https://github.com/Gogo1951/Open-Sesame)
-* [Discord](https://discord.gg/eh8hKq992Q)
+- [GitHub](https://github.com/Gogo1951/Open-Sesame)
+- [Discord](https://discord.gg/eh8hKq992Q)
 
 ## History
 
 👾 **I didn't create this add-on, I just updated it.**
 
-* lord_glofuss's [Auto Open Items](https://www.curseforge.com/wow/addons/auto-open-items)
-* pipsqueakcurse's [AutoClam](https://www.curseforge.com/wow/addons/autoclam)
-* fr0z3nights' [kAutoOpen Dragonflight](https://www.curseforge.com/wow/addons/kautoopen-dragonflight)
-* _ForgeUser1016257's [kAutoOpen](https://www.curseforge.com/wow/addons/kautoopen)
-* [Openables (Weak Aura)](https://wago.io/gtRVJZetK)
+- lord_glofuss's [Auto Open Items](https://www.curseforge.com/wow/addons/auto-open-items)
+- pipsqueakcurse's [AutoClam](https://www.curseforge.com/wow/addons/autoclam)
+- fr0z3nights' [kAutoOpen Dragonflight](https://www.curseforge.com/wow/addons/kautoopen-dragonflight)
+- _ForgeUser1016257's [kAutoOpen](https://www.curseforge.com/wow/addons/kautoopen)
+- [Openables (Weak Aura)](https://wago.io/gtRVJZetK)
 
 ## Related Add-ons
 


### PR DESCRIPTION
# Release Notes

Open Sesame gains Loot Toasts, a personal Ignore List, and Lockbox Tooltips. Auto-Opening now recognizes nearly 500 containers and can be told to stand down inside instances or in groups.

## New Features

* Loot Toasts show a brief on-screen notice for everything you pick up, so hiding the loot window no longer costs you the record of what you got.
* Loot Toasts are yours to arrange: drag them anywhere, then set the font, size, outline, duration, row count, and stacking direction.
* Bind on Pickup items, quest items, recipes, mounts, pets, keys, bags, containers, and money always show, whatever quality filter you set.
* An Ignore List keeps chosen containers sealed. Drag an item in, or paste a link or item ID, and both Auto-Opening and Speedy Loot leave it alone.
* The Ignore List ships seeded with containers usually worth more unopened, restores to those defaults in one click, and is shared by all of your characters.
* Hovering a locked box shows the Lockpicking skill it needs, colored on a rogue by whether yours clears it.
* The mini-map tooltip lists the locked boxes waiting in your bags.
* Auto-Opening can be limited to outside instances, or to solo play, so bag space stays free for drops.
* A separate Pick Pocket sound plays when a pickpocket comes up with something.

## Improvements

* Auto-Opening recognizes nearly 500 containers, up from about 350.
* Loot sound settings moved to a new Notifications tab, with a full minimum quality picker.
* Lockbox tooltips and notices can be shown to rogues only, or to every character.
* The Options Interface now refuses to open in combat and says why, instead of leaving you with a game error.
* Diagnostic Tools gained relevant CVar and display reports, so a bug report carries more of what it needs.

## Bug Fixes

* Speedy Loot now always says when it leaves an item behind. It used to stay quiet unless Auto-Opening and Lockbox Notifications were both switched on.
